### PR TITLE
Fix CBC app

### DIFF
--- a/apps/cbcrssfeed/cbc_rss_feed.star
+++ b/apps/cbcrssfeed/cbc_rss_feed.star
@@ -282,7 +282,7 @@ def get_cacheable_data(url, articlecount):
     # so we need to set it to literally anything different. If you encounter a vague "stream error",
     # try changing the user agent string to something else.
     res = http.get(RSS_STUB.format(url),  ttl_seconds = CACHE_TTL_SECONDS,
-                   headers= {"User-Agent": "Change-me-if-stream-error-occurs"})
+                   headers= {"User-Agent": "Mozilla/5.0 (compatible; Pixlet)"})
     if res.status_code != 200:
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
     data = res.body()


### PR DESCRIPTION
 The CBC app was failing to render because fetching the RSS feed
 would fail.
    
After investigation it seems the default user-agent is blocked
by the website.
    
This patch changes the user-agent header to literally anything else
to cheekily avoid this problem.
