### PR TITLE
Add a front-end app viewer

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,54 @@
+name: Build and Deploy App Viewer to GitHub Pages
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Generate apps.json
+        run: |
+          cd app-viewer
+          node generate-apps-json.js
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './app-viewer'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#25b7c6",
+        "activityBar.background": "#25b7c6",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#fae4f8",
+        "activityBarBadge.foreground": "#15202b",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#25b7c6",
+        "statusBar.background": "#1d8f9b",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#25b7c6",
+        "statusBarItem.remoteBackground": "#1d8f9b",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "tab.activeBorder": "#25b7c6",
+        "titleBar.activeBackground": "#1d8f9b",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#1d8f9b99",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.color": "#1d8f9b"
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![Discourse](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscuss.tidbyt.com&style=flat-square)](https://discuss.tidbyt.com/)
 [![Discord Server](https://img.shields.io/discord/928484660785336380?style=flat-square)](https://discord.gg/r45MXG4kZc)
 
+## 🔍 [**Browse Apps →**](https://tronbyt.github.io/apps/)
+
+**Explore all available apps with search, documentation, and screenshots in our interactive web viewer.**
+
 Tronbyt-Apps is a hard fork of the Tidbyt's Community repo. These apps have been developed by the [Tidbyt community][3] 🚀
 This exists because the Tidbyt folks have stopped merging pull requests since their acquisition by Modal.
 

--- a/app-viewer/app.html
+++ b/app-viewer/app.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>App Details</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="style.css">
+    </head>
+
+    <body>
+        <div class="container py-4">
+            <a href="index.html" class="btn btn-secondary mb-3" style="font-family: 'Press Start 2P', monospace;">← Back
+                to Apps</a>
+            <div id="app-content"></div>
+        </div>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+        <script src="main.js"></script>
+    </body>
+
+</html>

--- a/app-viewer/apps.json
+++ b/app-viewer/apps.json
@@ -1,0 +1,8167 @@
+[
+  {
+    "name": "3cellularautomata",
+    "image": "3cellularautomata/3cellularautomata.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "3cellularautomata.star"
+    ]
+  },
+  {
+    "name": "OctoWatts",
+    "image": "OctoWatts/Screenshot.png",
+    "md": "OctoWatts/README.md",
+    "description": "Octopus Energy live consumption monitor, diplays your current usage and one minute energy trend. Req...",
+    "starFiles": [
+      "octowatts.star"
+    ]
+  },
+  {
+    "name": "aadailyreflect",
+    "image": "aadailyreflect/aadailyreflect-1.png",
+    "md": "aadailyreflect/README.md",
+    "description": "AA Daily Reflection Shows the Daily Reflection from the AA.org/daily-reflection website Displayed: T...",
+    "starFiles": [
+      "aadailyreflect.star"
+    ]
+  },
+  {
+    "name": "abcradio",
+    "image": "abcradio/abcradio.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "abc_radio.star"
+    ]
+  },
+  {
+    "name": "abstractclock",
+    "image": "abstractclock/abstractclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "abstract_clock.star"
+    ]
+  },
+  {
+    "name": "accidentfreedays",
+    "image": "accidentfreedays/accidentfreedays.webp",
+    "md": "accidentfreedays/README.md",
+    "description": "Accident Free Days Displays the number of days since the last accident. !screenshot",
+    "starFiles": [
+      "accidentfreedays.star"
+    ]
+  },
+  {
+    "name": "accuweather",
+    "image": "accuweather/accuweather.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "accuweather.star"
+    ]
+  },
+  {
+    "name": "acfilmshowtimes",
+    "image": "acfilmshowtimes/acfilmshowtimes.webp",
+    "md": "acfilmshowtimes/README.md",
+    "description": "American Cinematheque Showtimes for Tidbyt !American Cinematheque app demo This app displays showtim...",
+    "starFiles": [
+      "ac_film_showtimes.star"
+    ]
+  },
+  {
+    "name": "acidwarp",
+    "image": "acidwarp/acidwarp.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "acidwarp.star"
+    ]
+  },
+  {
+    "name": "acnhvillager",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "acnhvillager.star"
+    ]
+  },
+  {
+    "name": "actransit",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "ac_transit.star"
+    ]
+  },
+  {
+    "name": "adafruitio",
+    "image": "adafruitio/adafruitio.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "adafruitio.star"
+    ]
+  },
+  {
+    "name": "adelaidemetro",
+    "image": "adelaidemetro/adelaide_metro_bus.gif",
+    "md": "adelaidemetro/README.md",
+    "description": "Inspired by all the other great transit apps out there, I made one for my home town. I'd be surprise...",
+    "starFiles": [
+      "adelaide_metro.star"
+    ]
+  },
+  {
+    "name": "advice",
+    "image": "advice/advice.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "advice.star"
+    ]
+  },
+  {
+    "name": "afl",
+    "image": "afl/afl.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "afl.star"
+    ]
+  },
+  {
+    "name": "aflladder",
+    "image": "aflladder/afl_ladder.gif",
+    "md": "aflladder/README.md",
+    "description": "The new AFL season is upon us so I've made an app that shows the AFL Ladder.\r \r !",
+    "starFiles": [
+      "afl_ladder.star"
+    ]
+  },
+  {
+    "name": "aflscores",
+    "image": "aflscores/Last_Round.gif",
+    "md": "aflscores/README.md",
+    "description": "The new AFL season is upon us so I've made an app that shows the match scores for the round - upcomi...",
+    "starFiles": [
+      "afl_scores.star"
+    ]
+  },
+  {
+    "name": "airbnbcalendar",
+    "image": "airbnbcalendar/airbnbcalendar.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "airbnb_calendar.star"
+    ]
+  },
+  {
+    "name": "airnow",
+    "image": "airnow/airnow.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "airnow.star"
+    ]
+  },
+  {
+    "name": "airquality",
+    "image": "airquality/air_quality.gif",
+    "md": "airquality/README.md",
+    "description": "Air Quality Overview This app uses the OpenWeather Air Pollution API to show the current Air Quality...",
+    "starFiles": [
+      "air_quality.star"
+    ]
+  },
+  {
+    "name": "airthings",
+    "image": "airthings/airthings.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "airthings.star"
+    ]
+  },
+  {
+    "name": "amazing",
+    "image": "amazing/amazing.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "amazing.star"
+    ]
+  },
+  {
+    "name": "ambientweather",
+    "image": "ambientweather/screenshot.png",
+    "md": "ambientweather/README.md",
+    "description": "Ambient Weather Ambient Weather displays details from your weather station. Displayed: Location Temp...",
+    "starFiles": [
+      "ambient_weather.star"
+    ]
+  },
+  {
+    "name": "americanmapbook",
+    "image": "americanmapbook/americanmapbook.webp",
+    "md": "americanmapbook/README.md",
+    "description": "American Mapbook Overview American Mapbook is your personal journey tracker across the United States...",
+    "starFiles": [
+      "americanmapbook.star"
+    ]
+  },
+  {
+    "name": "analogclock",
+    "image": "analogclock/analogclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "analog_clock.star"
+    ]
+  },
+  {
+    "name": "analogtime",
+    "image": "analogtime/analogtime.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "analog_time.star"
+    ]
+  },
+  {
+    "name": "anime_next_ep",
+    "image": "anime_next_ep/anime_next_ep.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "anime_next_ep.star"
+    ]
+  },
+  {
+    "name": "anycalendar",
+    "image": "anycalendar/any_calendar.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "any_calendar.star"
+    ]
+  },
+  {
+    "name": "anyprogressbar",
+    "image": "anyprogressbar/anyprogressbar.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "any_progressbar.star"
+    ]
+  },
+  {
+    "name": "apiimage",
+    "image": "apiimage/api_image.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "api_image.star"
+    ]
+  },
+  {
+    "name": "apitext",
+    "image": "apitext/apitext.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "api_text.star"
+    ]
+  },
+  {
+    "name": "aquarium",
+    "image": "aquarium/aquarium.webp",
+    "md": "aquarium/readme.md",
+    "description": "Aquarium for Tidbyt Created by: Robert Ison Displays an aquarium scene that changes each time with d...",
+    "starFiles": [
+      "aquarium.star"
+    ]
+  },
+  {
+    "name": "arcadeclassics",
+    "image": "arcadeclassics/arcadeclassics.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "arcade_classics.star"
+    ]
+  },
+  {
+    "name": "archerdog",
+    "image": "archerdog/archerdog.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "archer_dog.star"
+    ]
+  },
+  {
+    "name": "armageddontrackr",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "armageddon_trackr.star"
+    ]
+  },
+  {
+    "name": "astropicofday",
+    "image": "astropicofday/screenshot.png",
+    "md": "astropicofday/README.md",
+    "description": "Astro Pic of Day Applet for Tidbyt Displays NASA's Astronomy Picture of the Day on your Tidbyt using...",
+    "starFiles": [
+      "astro_pic_of_day.star"
+    ]
+  },
+  {
+    "name": "atb-bus-times",
+    "image": "atb-bus-times/atb_bus_times.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "atb_bus_times.star"
+    ]
+  },
+  {
+    "name": "atcradar",
+    "image": "atcradar/atc_radar.webp",
+    "md": "atcradar/readme.md",
+    "description": "ATC Radar for Tidbyt Air Traffic Control Radar or ATC Radar This application requires a RapidAPI API...",
+    "starFiles": [
+      "atc_radar.star"
+    ]
+  },
+  {
+    "name": "atptennis",
+    "image": "atptennis/atp_tennis.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "atp_tennis.star"
+    ]
+  },
+  {
+    "name": "avatarsinpixels",
+    "image": "avatarsinpixels/avatars_in_pixels.webp",
+    "md": "avatarsinpixels/README.md",
+    "description": "Avatars In Pixels Overview This app uses the Avatars In Pixels API to generate a random pixel art ch...",
+    "starFiles": [
+      "avatars_in_pixels.star"
+    ]
+  },
+  {
+    "name": "awair",
+    "image": "awair/awair.webp",
+    "md": "awair/README.md",
+    "description": "Awair An app to render data from an Awair device. Unconfigured: <img src=\"./screenshot-unconfigured....",
+    "starFiles": [
+      "awair.star"
+    ]
+  },
+  {
+    "name": "azhighwaysigns",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "az_highway_signs.star"
+    ]
+  },
+  {
+    "name": "azurestatus",
+    "image": "azurestatus/azure_status_noissues.gif",
+    "md": "azurestatus/README.md",
+    "description": "After a couple recent Azure outages, I decided to make a simple app that looks at the Azure Status R...",
+    "starFiles": [
+      "azure_status.star"
+    ]
+  },
+  {
+    "name": "babyage",
+    "image": "babyage/babyage.webp",
+    "md": "babyage/readme.md",
+    "description": "Baby Age for Tidbyt\r \r Simple app to show your baby's age in days (up to 30), weeks (up to 24) and m...",
+    "starFiles": [
+      "baby_age.star"
+    ]
+  },
+  {
+    "name": "babysteps",
+    "image": "babysteps/baby_steps.webp",
+    "md": "babysteps/readme.md",
+    "description": "Baby Steps for Tidbyt Dave Ramsey has 7 Baby Steps to financial freedom. If you are working on these...",
+    "starFiles": [
+      "baby_steps.star"
+    ]
+  },
+  {
+    "name": "baywheels",
+    "image": "baywheels/bay_wheels.gif",
+    "md": "baywheels/README.md",
+    "description": "BayWheels app for Tidbyt Displays availability of docked bikes at a BayWheels bike share station. Fe...",
+    "starFiles": [
+      "bay_wheels.star"
+    ]
+  },
+  {
+    "name": "bbcradio",
+    "image": "bbcradio/bbc_radio.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "bbc_radio.star"
+    ]
+  },
+  {
+    "name": "bbcsounds",
+    "image": "bbcsounds/bbc_sounds.webp",
+    "md": "bbcsounds/README.md",
+    "description": "BBC Sounds Show what's currently playing on BBC Sounds radio stations on your Tidbyt Settings You ca...",
+    "starFiles": [
+      "bbc_sounds.star"
+    ]
+  },
+  {
+    "name": "bblcricket",
+    "image": "bblcricket/bbl_cricket.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "bbl_cricket.star"
+    ]
+  },
+  {
+    "name": "bdaycountdown",
+    "image": "bdaycountdown/bdaycountdown.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "bday_countdown.star"
+    ]
+  },
+  {
+    "name": "beattime",
+    "image": "beattime/beat_time-1.png",
+    "md": "beattime/README.md",
+    "description": "Beat Time Display the time in _.beats_, a decimal time format also known as Swatch Internet Time Con...",
+    "starFiles": [
+      "beat_time.star"
+    ]
+  },
+  {
+    "name": "belifeed",
+    "image": "belifeed/beli_feed.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "beli_feed.star"
+    ]
+  },
+  {
+    "name": "berlintransit",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "berlin_transit.star"
+    ]
+  },
+  {
+    "name": "bestpicturepicker",
+    "image": "bestpicturepicker/bestpicturepicker.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "bestpicturepicker.star"
+    ]
+  },
+  {
+    "name": "betteroncall",
+    "image": "betteroncall/betteroncall.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "better_on_call.star"
+    ]
+  },
+  {
+    "name": "bgghotness",
+    "image": "bgghotness/bgghotness.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "bgg_hotness.star"
+    ]
+  },
+  {
+    "name": "bgglastplay",
+    "image": "bgglastplay/bgglastplay.webp",
+    "md": "bgglastplay/README.md",
+    "description": "BoardGameGeek Last Play app Leverages the BGG XML API2 to display the last game played by a bgg user...",
+    "starFiles": [
+      "bgg_last_play.star"
+    ]
+  },
+  {
+    "name": "bibleverse",
+    "image": "bibleverse/bibleverse.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "bible_verse.star"
+    ]
+  },
+  {
+    "name": "biblevotd",
+    "image": "biblevotd/biblevotd.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "bible_votd.star"
+    ]
+  },
+  {
+    "name": "bigbrothernews",
+    "image": "bigbrothernews/bigbrothernews.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "big_brother_news.star"
+    ]
+  },
+  {
+    "name": "bigclock",
+    "image": "bigclock/bigclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "big_clock.star"
+    ]
+  },
+  {
+    "name": "bikeshare",
+    "image": "bikeshare/bikeshare.png",
+    "md": "bikeshare/README.md",
+    "description": "Bikeshare Applet for Tidbyt Displays the availability of bikes and parking respectively for a user s...",
+    "starFiles": [
+      "bikeshare.star"
+    ]
+  },
+  {
+    "name": "billboardtop10",
+    "image": "billboardtop10/billboardtop10.webp",
+    "md": "billboardtop10/readme.md",
+    "description": "Billboard Top 10 for Tidbyt Display the Bill Board Top 10 -- you can pick US Charts, Global Charts o...",
+    "starFiles": [
+      "billboardtop10.star"
+    ]
+  },
+  {
+    "name": "binaryclock",
+    "image": "binaryclock/binaryclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "binary_clock.star"
+    ]
+  },
+  {
+    "name": "biorhythm",
+    "image": "biorhythm/biorhythm.png",
+    "md": "biorhythm/README.md",
+    "description": "Biorhythm --- This app renders the physical (<b>P</b>), emotional (<b>E</b>), and intellectual (<b>I...",
+    "starFiles": [
+      "biorhythm.star"
+    ]
+  },
+  {
+    "name": "birdbyt",
+    "image": "birdbyt/birdbyt.gif",
+    "md": "birdbyt/README.md",
+    "description": "Birdbyt Birdbyt displays bird sightings near your location. Notable bird sightings are accompanied b...",
+    "starFiles": [
+      "birdbyt.star"
+    ]
+  },
+  {
+    "name": "birdweather",
+    "image": "birdweather/birdweather.webp",
+    "md": "birdweather/README.md",
+    "description": "Birdweather Sightings from Birdweather Display sightings from a Birdweather station using their API ...",
+    "starFiles": [
+      "birdweather.star"
+    ]
+  },
+  {
+    "name": "bitcointicker",
+    "image": "bitcointicker/bitcointicker.webp",
+    "md": "bitcointicker/README.md",
+    "description": "BitcoinTicker Applet for Tidbyt Shows the price of Bitcoin, including the market capitalisation, cha...",
+    "starFiles": [
+      "bitcointicker.star"
+    ]
+  },
+  {
+    "name": "bkkschedule",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "bkk_schedule.star"
+    ]
+  },
+  {
+    "name": "blackout",
+    "image": "blackout/blackout.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "blackout.star"
+    ]
+  },
+  {
+    "name": "bluebikes",
+    "image": "bluebikes/bluebikes.gif",
+    "md": "bluebikes/README.md",
+    "description": "Boston Bluebikes Displays how many classic bikes, e-bikes, and docks are available at a Bluebikes st...",
+    "starFiles": [
+      "bluebikes.star"
+    ]
+  },
+  {
+    "name": "bluebomber",
+    "image": "bluebomber/screenshot.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "bluebomber.star"
+    ]
+  },
+  {
+    "name": "blueskyusers",
+    "image": "blueskyusers/blueskyusers.webp",
+    "md": "blueskyusers/README.md",
+    "description": "Bluesky Users Overview This is a simple app that displays the total number of users on the Bluesky s...",
+    "starFiles": [
+      "bluesky_users.star"
+    ]
+  },
+  {
+    "name": "bofhquotes",
+    "image": "bofhquotes/bofhquotes.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "bofh_quotes.star"
+    ]
+  },
+  {
+    "name": "bored",
+    "image": "bored/bored.gif",
+    "md": "bored/README.md",
+    "description": "Bored Releases Version 2.0001 WOOOOAAA now you can enter your OWN suggestions for things to do, thus...",
+    "starFiles": [
+      "bored.star"
+    ]
+  },
+  {
+    "name": "borisbikes",
+    "image": "borisbikes/boris_bikes.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "boris_bikes.star"
+    ]
+  },
+  {
+    "name": "braemarscreen",
+    "image": "braemarscreen/braemarscreen.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "braemar_screen.star"
+    ]
+  },
+  {
+    "name": "brawlstarsmaps",
+    "image": "brawlstarsmaps/brawlstarsmaps.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "brawlstars_maps.star"
+    ]
+  },
+  {
+    "name": "breadwinner",
+    "image": "breadwinner/breadwinner.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "breadwinner.star"
+    ]
+  },
+  {
+    "name": "breakingbad",
+    "image": "breakingbad/breakingbad.webp",
+    "md": "breakingbad/readme.md",
+    "description": "Breaking Bad for Tidbyt Create your own Credit in the Breaking Bad format. !Breaking Bad for Tidbyt",
+    "starFiles": [
+      "breakingbad.star"
+    ]
+  },
+  {
+    "name": "btcdifficulty",
+    "image": "btcdifficulty/btcdifficulty.webp",
+    "md": "btcdifficulty/README.md",
+    "description": "BtcDifficulty Applet for Tidbyt Displays the difficulty adjustment progress of Bitcoin and gives an ...",
+    "starFiles": [
+      "btcdifficulty.star"
+    ]
+  },
+  {
+    "name": "btcfagi",
+    "image": "btcfagi/btcfagi.webp",
+    "md": "btcfagi/README.md",
+    "description": "BtcFagi Applet for Tidbyt Shows the 'Fear And Greed Index' for Bitcoin. Data provided by Alternative...",
+    "starFiles": [
+      "btcfagi.star"
+    ]
+  },
+  {
+    "name": "btchalving",
+    "image": "btchalving/btchalving.webp",
+    "md": "btchalving/README.md",
+    "description": "BtcHalving Applet for Tidbyt Shows the Bitcoin halving progress and the difficulty adjustment progre...",
+    "starFiles": [
+      "btchalving.star"
+    ]
+  },
+  {
+    "name": "btcmoscowtime",
+    "image": "btcmoscowtime/btcmoscowtime.webp",
+    "md": "btcmoscowtime/README.md",
+    "description": "BtcMoscowTime Applet for Tidbyt Shows how many satoshis for 1 USD (note: a satoshi is 0.00000001 bit...",
+    "starFiles": [
+      "btcmoscowtime.star"
+    ]
+  },
+  {
+    "name": "buienradar",
+    "image": "buienradar/buienradar.webp",
+    "md": "buienradar/README.md",
+    "description": "Buienradar Applet for Tidbyt Shows the buienradar of Belgium or The Netherlands. Note: temperatures ...",
+    "starFiles": [
+      "buienradar.star"
+    ]
+  },
+  {
+    "name": "burgeroftheday",
+    "image": "burgeroftheday/burgerotd.webp",
+    "md": "burgeroftheday/README.md",
+    "description": "Burger of the Day Applet for Tidbyt Displays the Burger of the Day from the show \"Bob's Burgers\". A ...",
+    "starFiles": [
+      "burgerotd.star"
+    ]
+  },
+  {
+    "name": "busytube",
+    "image": "busytube/busy_tube.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "busy_tube.star"
+    ]
+  },
+  {
+    "name": "calendars",
+    "image": "calendars/calendars.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "calendars.star"
+    ]
+  },
+  {
+    "name": "caltrain",
+    "image": "caltrain/caltrain.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "caltrain.star"
+    ]
+  },
+  {
+    "name": "campark",
+    "image": "campark/campark.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "campark.star"
+    ]
+  },
+  {
+    "name": "candystatus",
+    "image": "candystatus/candystatus.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "candystatus.star"
+    ]
+  },
+  {
+    "name": "canvas",
+    "image": "canvas/canvas.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "canvas.star"
+    ]
+  },
+  {
+    "name": "capital_bikeshare",
+    "image": "capital_bikeshare/capital_bikeshare.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "capital_bikeshare.star"
+    ]
+  },
+  {
+    "name": "carenewables",
+    "image": "carenewables/screenshot.png",
+    "md": "carenewables/README.md",
+    "description": "CA Renewables Watch the CA power grid and track what renewable power sources are providing the most ...",
+    "starFiles": [
+      "ca_renewables.star"
+    ]
+  },
+  {
+    "name": "catfact",
+    "image": "catfact/catfact.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "catfact.star"
+    ]
+  },
+  {
+    "name": "cbcrssfeed",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cbc_rss_feed.star"
+    ]
+  },
+  {
+    "name": "cellartrackerrtd",
+    "image": "cellartrackerrtd/cellartrackerrtd.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cellartrackerrtd.star"
+    ]
+  },
+  {
+    "name": "cellularautomata",
+    "image": "cellularautomata/cellularautomata.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cellularautomata.star"
+    ]
+  },
+  {
+    "name": "cflscores",
+    "image": "cflscores/screenshot.png",
+    "md": "cflscores/README.md",
+    "description": "CFL Scores for Tidbyt Displays live CFL scores and gambling odds for upcoming games. Updated every 2...",
+    "starFiles": [
+      "cfl_scores.star"
+    ]
+  },
+  {
+    "name": "charlestownferry",
+    "image": "charlestownferry/charlestownferry.webp",
+    "md": "charlestownferry/README.md",
+    "description": "Charlestown, MA Ferry Departure Times for Tidbyt Displays the next three departure times for the Cha...",
+    "starFiles": [
+      "charlestownferry.star"
+    ]
+  },
+  {
+    "name": "chartmogularr",
+    "image": "chartmogularr/chartmogularr.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "chartmogul_arr.star"
+    ]
+  },
+  {
+    "name": "chchbins",
+    "image": "chchbins/christchurch_bins.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "christchurch_bins.star"
+    ]
+  },
+  {
+    "name": "checkiday",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "checkiday.star"
+    ]
+  },
+  {
+    "name": "chemicalelements",
+    "image": "chemicalelements/chemical_elements.webp",
+    "md": "chemicalelements/readme.md",
+    "description": "Chemical Elements for Tidbyt Created by: Robert Ison Displays one of the chemical elements at a time...",
+    "starFiles": [
+      "chemical_elements.star"
+    ]
+  },
+  {
+    "name": "chesscomelo",
+    "image": "chesscomelo/chesscomelo.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "chesscom_elo.star"
+    ]
+  },
+  {
+    "name": "chessviewer",
+    "image": "chessviewer/screenshot.png",
+    "md": "chessviewer/readme.md",
+    "description": "Chess Viewer App for Tidbyt Displays currently active games from Chess.com for the username provided...",
+    "starFiles": [
+      "chess_viewer.star"
+    ]
+  },
+  {
+    "name": "chi-l-track",
+    "image": "chi-l-track/chi_l_track.gif",
+    "md": "chi-l-track/README.md",
+    "description": "Chi L Track Chicago CTA L Tracker - Station arrival board An arrival board for your favorite 'L' sta...",
+    "starFiles": [
+      "chi_l_track.star"
+    ]
+  },
+  {
+    "name": "chicagodivvy",
+    "image": "chicagodivvy/screenshot.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "chicago_divvy.star"
+    ]
+  },
+  {
+    "name": "chicagotribune",
+    "image": "chicagotribune/chicago_tribune.webp",
+    "md": "chicagotribune/README.md",
+    "description": "Chicago Tribune Display the latest headlines or the latest article from the Chicago Tribune's RSS fe...",
+    "starFiles": [
+      "chicago_tribune.star"
+    ]
+  },
+  {
+    "name": "christmascountdown",
+    "image": "christmascountdown/christmascountdown.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "christmascountdown.star"
+    ]
+  },
+  {
+    "name": "chrono24",
+    "image": "chrono24/screenshot.png",
+    "md": "chrono24/README.md",
+    "description": "Chrono24 !Chrono24 This Chrono24 app shows two different views. Overall market performance Top 10 wa...",
+    "starFiles": [
+      "chrono24.star"
+    ]
+  },
+  {
+    "name": "circleci",
+    "image": "circleci/circleci.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "circleci.star"
+    ]
+  },
+  {
+    "name": "citibikebymk",
+    "image": "citibikebymk/citibike_by_mk.gif",
+    "md": "citibikebymk/readme.md",
+    "description": "Citibike by MK, by Michael Kleban\r \r Allows the user to search for a Citibike station and displays t...",
+    "starFiles": [
+      "citibike_by_mk.star"
+    ]
+  },
+  {
+    "name": "clashclanstrophy",
+    "image": "clashclanstrophy/clashclanstrophy.gif",
+    "md": "clashclanstrophy/readme.md",
+    "description": "ClashClanTrophy Author: Brandon Marks A program made to display trophy count for clash of clans. <im...",
+    "starFiles": [
+      "clashclanstrophy.star"
+    ]
+  },
+  {
+    "name": "climateclock",
+    "image": "climateclock/climateclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "climate_clock.star"
+    ]
+  },
+  {
+    "name": "clockbyhenry",
+    "image": "clockbyhenry/clockbyhenry.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "clock_by_henry.star"
+    ]
+  },
+  {
+    "name": "clockwithseconds",
+    "image": "clockwithseconds/clockwithseconds.webp",
+    "md": "clockwithseconds/README.md",
+    "description": "clockwithseconds Overview This app shows a clock with seconds. Configuration (Schema) The app suppor...",
+    "starFiles": [
+      "clockwithseconds.star"
+    ]
+  },
+  {
+    "name": "cltlightrail",
+    "image": "cltlightrail/cltlightrail.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "clt_lightrail.star"
+    ]
+  },
+  {
+    "name": "co2signal",
+    "image": "co2signal/co2signal.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "co2_signal.star"
+    ]
+  },
+  {
+    "name": "coffee",
+    "image": "coffee/coffee.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "coffee.star"
+    ]
+  },
+  {
+    "name": "coffeeorders",
+    "image": "coffeeorders/coffeeorders.webp",
+    "md": "coffeeorders/readme.md",
+    "description": "Coffee for Tidbyt Created by: Robert Ison Displays either a random coffee image, or a random coffee ...",
+    "starFiles": [
+      "coffeeorders.star"
+    ]
+  },
+  {
+    "name": "coinbase",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "coinbase.star"
+    ]
+  },
+  {
+    "name": "coingeckoprice",
+    "image": "coingeckoprice/screenshot.png",
+    "md": "coingeckoprice/README.md",
+    "description": "CoinGecko Crypto Price Applet for Tidbyt Display the price of any cryptocurrency supported by CoinGe...",
+    "starFiles": [
+      "coingecko_price.star"
+    ]
+  },
+  {
+    "name": "coinprices",
+    "image": "coinprices/coinpricedocs.png",
+    "md": "coinprices/README.md",
+    "description": "!Coin Price Applet for Tidbyt Motivation Display one exchange rate against another of your choice on...",
+    "starFiles": [
+      "coin_prices.star"
+    ]
+  },
+  {
+    "name": "colorado14ers",
+    "image": "colorado14ers/colorado14ers.webp",
+    "md": "colorado14ers/readme.md",
+    "description": "Colorado 14ers Applet for Tidbyt Displays the location of Colorado Peaks that are 14,000 feet or tal...",
+    "starFiles": [
+      "colorado14ers.star"
+    ]
+  },
+  {
+    "name": "colorblocks",
+    "image": "colorblocks/colorblocks.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "colorblocks.star"
+    ]
+  },
+  {
+    "name": "colorfulclock",
+    "image": "colorfulclock/colorfulclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "colorful_clock.star"
+    ]
+  },
+  {
+    "name": "comed_price",
+    "image": "comed_price/comed_price.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "comed_price.star"
+    ]
+  },
+  {
+    "name": "compactstocks",
+    "image": "compactstocks/demo.jpg",
+    "md": "compactstocks/README.md",
+    "description": "Compact Stocks for Tidbyt This is a simple stock ticker app for Tidbyt that shows the current prices...",
+    "starFiles": [
+      "stocks.star"
+    ]
+  },
+  {
+    "name": "company_clock",
+    "image": "company_clock/company_clock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "company_clock.star"
+    ]
+  },
+  {
+    "name": "congresswatch",
+    "image": "congresswatch/congress_watch.webp",
+    "md": "congresswatch/readme.md",
+    "description": "Congress Watch Applet for Tidbyt Displays the laws that congress is working on. Allows you to filter...",
+    "starFiles": [
+      "congress_watch.star"
+    ]
+  },
+  {
+    "name": "corporatebsgen",
+    "image": "corporatebsgen/corporatebsgen.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "corporate_bs_gen.star"
+    ]
+  },
+  {
+    "name": "costcalculator",
+    "image": "costcalculator/costcalculator.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cost_calculator.star"
+    ]
+  },
+  {
+    "name": "costcogas",
+    "image": "costcogas/costcogas.webp",
+    "md": "costcogas/README.md",
+    "description": "Costco Gas Applet for Tidbyt Displays current gas prices for a selected Costco warehouse in the US. ...",
+    "starFiles": [
+      "costco_gas.star"
+    ]
+  },
+  {
+    "name": "countdownclock",
+    "image": "countdownclock/countdown_clock.gif",
+    "md": "countdownclock/README.md",
+    "description": "Countdown Clock Displays the days, hours, and minutes left until a specified event time. !screenshot",
+    "starFiles": [
+      "countdown_clock.star"
+    ]
+  },
+  {
+    "name": "countdowntimer",
+    "image": "countdowntimer/countdowntimer.webp",
+    "md": "countdowntimer/README.md",
+    "description": "Countdown Timer for Tidbyt A beautiful, customizable countdown timer app for Tidbyt that displays th...",
+    "starFiles": [
+      "countdowntimer.star"
+    ]
+  },
+  {
+    "name": "countupclock",
+    "image": "countupclock/countupclock-1.png",
+    "md": "countupclock/README.md",
+    "description": "Countup Clock Shows title and elapsed time since a defined date and time Displayed: Title (above or ...",
+    "starFiles": [
+      "countupclock.star"
+    ]
+  },
+  {
+    "name": "cpblLivescore",
+    "image": "cpblLivescore/cpbllivescore.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cpbl_live_score.star"
+    ]
+  },
+  {
+    "name": "cpblscores",
+    "image": "cpblscores/cpblscores.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cpbl_scores.star"
+    ]
+  },
+  {
+    "name": "cpblscores-betsapi",
+    "image": "cpblscores-betsapi/cpbl_scoreboard.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cpbl_scoreboard.star"
+    ]
+  },
+  {
+    "name": "cpitracker",
+    "image": "cpitracker/cpi_tracker.webp",
+    "md": "cpitracker/readme.md",
+    "description": "CPI Tracker Applet for Tidbyt Displays CPI Data from the U.S. Bereau of Labor Statistics - see www.b...",
+    "starFiles": [
+      "cpi_tracker.star"
+    ]
+  },
+  {
+    "name": "cpl",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cpl.star"
+    ]
+  },
+  {
+    "name": "craftnft",
+    "image": "craftnft/craftnft.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "craftnft.star"
+    ]
+  },
+  {
+    "name": "cranimechecker",
+    "image": "cranimechecker/cranimechecker.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cranimechecker.star"
+    ]
+  },
+  {
+    "name": "cricketworldcup",
+    "image": "cricketworldcup/cricket_world_cup 1.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cricket_world_cup.star"
+    ]
+  },
+  {
+    "name": "criticalchicken",
+    "image": "criticalchicken/criticalchicken.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "critical_chicken.star"
+    ]
+  },
+  {
+    "name": "cryptotracker",
+    "image": "cryptotracker/screenshot.png",
+    "md": "cryptotracker/README.md",
+    "description": "Crypto Tracker for Tidbyt Displays one of 5 24-hour cryptocurrency price charts in USD on your Tidby...",
+    "starFiles": [
+      "crypto_tracker.star"
+    ]
+  },
+  {
+    "name": "csvviewer",
+    "image": "csvviewer/csvviewer.webp",
+    "md": "csvviewer/README.md",
+    "description": "CSV Viewer This applet allows you to display CSV data from any online CSV file such as a published G...",
+    "starFiles": [
+      "csvviewer.star"
+    ]
+  },
+  {
+    "name": "ctaLStatus",
+    "image": "ctaLStatus/ctaLStatus.webp",
+    "md": "ctaLStatus/README.md",
+    "description": "CTA 'L' Status Display the status of the CTA 'L' along with any travel alerts Feeds CTA Status API C...",
+    "starFiles": [
+      "ctaLStatus.star"
+    ]
+  },
+  {
+    "name": "cta_train_tracker",
+    "image": "cta_train_tracker/cta_train_tracker.gif",
+    "md": "cta_train_tracker/README.md",
+    "description": "CTA train arrival times A small app to turn your tidbyt into a CTA board, it can track 'L' train arr...",
+    "starFiles": [
+      "cta_train_tracker.star"
+    ]
+  },
+  {
+    "name": "ctabustracker",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cta_bus_tracker.star"
+    ]
+  },
+  {
+    "name": "ctaltracker",
+    "image": "ctaltracker/cta_l_tracker.png",
+    "md": "ctaltracker/README.md",
+    "description": "CTA \"L\" Tracker Applet for Tidbyt Displays the two next arriving trains and their estimated arrival ...",
+    "starFiles": [
+      "cta_l_tracker.star"
+    ]
+  },
+  {
+    "name": "ctquotes",
+    "image": "ctquotes/ctquotes.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "ct_quotes.star"
+    ]
+  },
+  {
+    "name": "culvers",
+    "image": "culvers/culvers.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "culvers.star"
+    ]
+  },
+  {
+    "name": "cuneiform",
+    "image": "cuneiform/KAD3.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "cuneiform.star"
+    ]
+  },
+  {
+    "name": "currencyconverter",
+    "image": "currencyconverter/currencyconverter.gif",
+    "md": "currencyconverter/readme.md",
+    "description": "Currency Converter for Tidbyt Created by: Robert Ison Displays the exchange rate of two currencies. ...",
+    "starFiles": [
+      "currencyconverter.star"
+    ]
+  },
+  {
+    "name": "customclock",
+    "image": "customclock/customclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "custom_clock.star"
+    ]
+  },
+  {
+    "name": "customquotes",
+    "image": "customquotes/customquotes.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "custom_quotes.star"
+    ]
+  },
+  {
+    "name": "customstatus",
+    "image": "customstatus/customstatus.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "custom_status.star"
+    ]
+  },
+  {
+    "name": "cyclecast",
+    "image": "cyclecast/cyclecast.webp",
+    "md": "cyclecast/readme.md",
+    "description": "CycleCast for Tidbyt Displays weather information at a glance to quickly size up if it's a nice time...",
+    "starFiles": [
+      "cyclecast.star"
+    ]
+  },
+  {
+    "name": "czechianews",
+    "image": "czechianews/czechianews.webp",
+    "md": "czechianews/README.md",
+    "description": "To display Czech headline news on your Tidbyt, you can use sources like seznamzpravy.cz or irozhlas....",
+    "starFiles": [
+      "czechianews.star"
+    ]
+  },
+  {
+    "name": "dailycountdown",
+    "image": "dailycountdown/dailycountdown.webp",
+    "md": "dailycountdown/README.md",
+    "description": "Daily Countdown Author: Jeffery Bennett A countdown designed to display a daily countdown to a speci...",
+    "starFiles": [
+      "dailycountdown.star"
+    ]
+  },
+  {
+    "name": "dailyhoroscope",
+    "image": "dailyhoroscope/daily_horoscope.gif",
+    "md": "dailyhoroscope/README.md",
+    "description": "Daily Horoscope for Tidbyt Displays the specified daily horoscope from USA Today (currently thanks t...",
+    "starFiles": [
+      "daily_horoscope.star"
+    ]
+  },
+  {
+    "name": "dailykanji",
+    "image": "dailykanji/dailykanji.webp",
+    "md": "dailykanji/readme.md",
+    "description": "Daily Kanji for Tidbyt Displays a new kanji for everyone every couple hours. Gives you time to learn...",
+    "starFiles": [
+      "dailykanji.star"
+    ]
+  },
+  {
+    "name": "dailyreminder",
+    "image": "dailyreminder/screenshot.png",
+    "md": "dailyreminder/README.md",
+    "description": "Set a simple reminder for each day of the week. So you'll never forget to take out the trash, or tha...",
+    "starFiles": [
+      "daily_reminder.star"
+    ]
+  },
+  {
+    "name": "datadogcharts",
+    "image": "datadogcharts/datadogcharts.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "datadog_charts.star"
+    ]
+  },
+  {
+    "name": "datadogmonitors",
+    "image": "datadogmonitors/screenshot.png",
+    "md": "datadogmonitors/README.md",
+    "description": "DataDog Monitors for Tidbyt Displays any triggered monitors connected to your DataDog account. A val...",
+    "starFiles": [
+      "datadog_monitors.star"
+    ]
+  },
+  {
+    "name": "dateprogress",
+    "image": "dateprogress/dateprogress.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "date_progress.star"
+    ]
+  },
+  {
+    "name": "datetimeclock",
+    "image": "datetimeclock/datetimeclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "date_time_clock.star"
+    ]
+  },
+  {
+    "name": "daynightmap",
+    "image": "daynightmap/daynightmap.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "day_night_map.star"
+    ]
+  },
+  {
+    "name": "dayssince",
+    "image": "dayssince/dayssince.webp",
+    "md": "dayssince/README.md",
+    "description": "Days Since Displays the number of days since the incident supplied in the free text box. !screenshot",
+    "starFiles": [
+      "days_since.star"
+    ]
+  },
+  {
+    "name": "daystostpats",
+    "image": "daystostpats/daystostpats.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "days_to_st_pats.star"
+    ]
+  },
+  {
+    "name": "daystoxmas",
+    "image": "daystoxmas/screenshot.png",
+    "md": "daystoxmas/README.md",
+    "description": "Days to Xmas Countdown Applet for Tidbyt Display a countdown of days left til Christmas Day. !Days t...",
+    "starFiles": [
+      "days_to_xmas.star"
+    ]
+  },
+  {
+    "name": "dcbustimes",
+    "image": "dcbustimes/dc_bus_times.gif",
+    "md": "dcbustimes/README.md",
+    "description": "DC (WMATA) Bus Arrival Times This app utilizes an API provided by WMATA to display the next several ...",
+    "starFiles": [
+      "dc_bus_times.star"
+    ]
+  },
+  {
+    "name": "dcnexttrain",
+    "image": "dcnexttrain/Screenshot 1.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "dc_next_train.star"
+    ]
+  },
+  {
+    "name": "deathvalleytemp",
+    "image": "deathvalleytemp/deathvalleytemp.webp",
+    "md": "deathvalleytemp/README.md",
+    "description": "Death Valley Thermometer for Tidbyt Based off the Death Valley National Park thermometers, this app ...",
+    "starFiles": [
+      "deathvalleytemp.star"
+    ]
+  },
+  {
+    "name": "defcon",
+    "image": "defcon/defcon.gif",
+    "md": "defcon/readme.md",
+    "description": "Defcon for Tidbyt Displays the estimated DefCon (Defense Condition) alert level for the U.S. The sou...",
+    "starFiles": [
+      "defcon.star"
+    ]
+  },
+  {
+    "name": "defector",
+    "image": "defector/defector.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "defector.star"
+    ]
+  },
+  {
+    "name": "dense_time_temp",
+    "image": "dense_time_temp/dense_time_temp.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "dense_time_temp.star"
+    ]
+  },
+  {
+    "name": "denser_bart",
+    "image": "denser_bart/denser_bart.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "denser_bart.star"
+    ]
+  },
+  {
+    "name": "desknametag",
+    "image": "desknametag/screenshot.png",
+    "md": "desknametag/README.md",
+    "description": "Desk Name Tag Display your name, title, and pronouns to coworkers. Add your details to the Tidbyt ap...",
+    "starFiles": [
+      "desk_name_tag.star"
+    ]
+  },
+  {
+    "name": "destiny2stats",
+    "image": "destiny2stats/Screenshot.png",
+    "md": "destiny2stats/README.md",
+    "description": "Destiny 2 Stats Displays the emblem, race, class, and light level of your most recently played desti...",
+    "starFiles": [
+      "destiny_2_stats.star"
+    ]
+  },
+  {
+    "name": "detailedmetar",
+    "image": "detailedmetar/detailedmetar.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "detailedmetar.star"
+    ]
+  },
+  {
+    "name": "developerexcuse",
+    "image": "developerexcuse/developerexcuse.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "developer_excuse.star"
+    ]
+  },
+  {
+    "name": "diablo4events",
+    "image": "diablo4events/diablo4events.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "diablo_4_events.star"
+    ]
+  },
+  {
+    "name": "diescoreboardgt",
+    "image": "diescoreboardgt/diescoreboardgt.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "die_scoreboard_gt.star"
+    ]
+  },
+  {
+    "name": "digibyteprice",
+    "image": "digibyteprice/screenshot.png",
+    "md": "digibyteprice/README.md",
+    "description": "DigiByte Price Applet for Tidbyt Displays the current DigiByte price on your Tidbyt in up to two fia...",
+    "starFiles": [
+      "digibyte_price.star"
+    ]
+  },
+  {
+    "name": "digitalrain",
+    "image": "digitalrain/digitalrain.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "digital_rain.star"
+    ]
+  },
+  {
+    "name": "discordmembers",
+    "image": "discordmembers/discordmembers.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "discordmembers.star"
+    ]
+  },
+  {
+    "name": "dishwasher",
+    "image": "dishwasher/dishwasher.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "dishwasher.star"
+    ]
+  },
+  {
+    "name": "divbyt",
+    "image": "divbyt/mrdiv_gifs.webp",
+    "md": "divbyt/README.md",
+    "description": "Divbyt Looping geometric animations from animated GIF artist Mr. Div, designed specifically for Tidb...",
+    "starFiles": [
+      "mrdiv_gifs.star"
+    ]
+  },
+  {
+    "name": "divvy",
+    "image": "divvy/divvy.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "divvy.star"
+    ]
+  },
+  {
+    "name": "dolarblue",
+    "image": "dolarblue/dolarblue.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "dolar_blue.star"
+    ]
+  },
+  {
+    "name": "domewatch",
+    "image": "domewatch/domewatch.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "dome_watch.star"
+    ]
+  },
+  {
+    "name": "doorbell",
+    "image": "doorbell/doorbell.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "doorbell.star"
+    ]
+  },
+  {
+    "name": "dothrakiwotd",
+    "image": "dothrakiwotd/dothrakiwotd.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "dothraki_wotd.star"
+    ]
+  },
+  {
+    "name": "drawbridgestatus",
+    "image": "drawbridgestatus/drawbridge_status_available_en.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "drawbridge_status.star"
+    ]
+  },
+  {
+    "name": "dryer",
+    "image": "dryer/dryer.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "dryer.star"
+    ]
+  },
+  {
+    "name": "duolingo",
+    "image": "duolingo/dayview.png",
+    "md": "duolingo/README.md",
+    "description": "Duolingo Dashboard for Tidbyt This applet provides a user dashboard for Duolingo. The app has three ...",
+    "starFiles": [
+      "duolingo.star"
+    ]
+  },
+  {
+    "name": "dutchfuzzyclock",
+    "image": "dutchfuzzyclock/dutch_fuzzy_clock.webp",
+    "md": "dutchfuzzyclock/README.md",
+    "description": "Dutch Fuzzy Clock Displays the time of the day in human readable form in the Dutch way. Heavily insp...",
+    "starFiles": [
+      "dutch_fuzzy_clock.star"
+    ]
+  },
+  {
+    "name": "dvdlogo",
+    "image": "dvdlogo/dvdlogo.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "dvd_logo.star"
+    ]
+  },
+  {
+    "name": "dwheadline",
+    "image": "dwheadline/screenshot.png",
+    "md": "dwheadline/README.md",
+    "description": "DailyWire.com Headlines for Tidbyt Displays the most recent headline published to the DailyWire.com....",
+    "starFiles": [
+      "dw_headline.star"
+    ]
+  },
+  {
+    "name": "earthquakemap",
+    "image": "earthquakemap/earthquake_map.gif",
+    "md": "earthquakemap/README.md",
+    "description": "<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Tem...",
+    "starFiles": [
+      "earthquake_map.star"
+    ]
+  },
+  {
+    "name": "edinburghbus",
+    "image": "edinburghbus/edinburghbus.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "edinburgh_bus.star"
+    ]
+  },
+  {
+    "name": "effheadlines",
+    "image": "effheadlines/effheadlines.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "effheadlines.star"
+    ]
+  },
+  {
+    "name": "emojilingo",
+    "image": "emojilingo/emojilingo.webp",
+    "md": "emojilingo/README.md",
+    "description": "Emoji Lingo for Tidbyt By: Cedric Sam See: https://github.com/cedricsam/emoji-lingo",
+    "starFiles": [
+      "emoji_lingo.star"
+    ]
+  },
+  {
+    "name": "enphasesolar",
+    "image": "enphasesolar/enphasesolar.webp",
+    "md": "enphasesolar/README.md",
+    "description": "Enphase Solar Tidbyt App to display energy generated by Solar Panels via Enlighten API v4. Usage In ...",
+    "starFiles": [
+      "enphase_solar.star"
+    ]
+  },
+  {
+    "name": "envoydesk",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "envoy_desk.star"
+    ]
+  },
+  {
+    "name": "eplscores",
+    "image": "eplscores/eplscores.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "eplscores.star"
+    ]
+  },
+  {
+    "name": "esbnyccolors",
+    "image": "esbnyccolors/esbnyccolors.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "esb_nyc_colors.star"
+    ]
+  },
+  {
+    "name": "espnfantasyfootball",
+    "image": "espnfantasyfootball/espn_fantasy_fb.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "espn_fantasy_fb.star"
+    ]
+  },
+  {
+    "name": "espnffstandings",
+    "image": "espnffstandings/espnffstandings.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "espn_ff_standings.star"
+    ]
+  },
+  {
+    "name": "espnnews",
+    "image": "espnnews/espnnews.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "espn_news.star"
+    ]
+  },
+  {
+    "name": "ethstaker",
+    "image": "ethstaker/screenshot.png",
+    "md": "ethstaker/README.md",
+    "description": "ethstaker for Tidbyt Displays the recent validator status history for validators on the Ethereum bea...",
+    "starFiles": [
+      "ethstaker.star"
+    ]
+  },
+  {
+    "name": "euromillions",
+    "image": "euromillions/euromillions.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "euromillions.star"
+    ]
+  },
+  {
+    "name": "evcc",
+    "image": "evcc/evcc.webp",
+    "md": "evcc/README.md",
+    "description": "EVCC evcc is an energy management system with a focus on electromobility. The software controls your...",
+    "starFiles": [
+      "evcc.star"
+    ]
+  },
+  {
+    "name": "eventprogress",
+    "image": "eventprogress/eventprogress.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "eventprogress.star"
+    ]
+  },
+  {
+    "name": "exotic_clocks",
+    "image": "exotic_clocks/exotic_clocks.webp",
+    "md": "exotic_clocks/README.md",
+    "description": "Exotic Clocks An app that tells time in a stylish and localized way. Thai Time Display time based on...",
+    "starFiles": [
+      "exotic_clocks.star"
+    ]
+  },
+  {
+    "name": "f1results",
+    "image": "f1results/f1_results.gif",
+    "md": "f1results/README.md",
+    "description": "With the start of the new F1 season, I've made an app that shows qualifying and race results for the...",
+    "starFiles": [
+      "f1_results.star"
+    ]
+  },
+  {
+    "name": "faaatis",
+    "image": "faaatis/faa_atis.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "faa_atis.star"
+    ]
+  },
+  {
+    "name": "faadelays",
+    "image": "faadelays/faadelays.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "faa_delays.star"
+    ]
+  },
+  {
+    "name": "fairfaxconnector",
+    "image": "fairfaxconnector/ffxconnector.gif",
+    "md": "fairfaxconnector/README.md",
+    "description": "Fairfax Connector Tidbyt App\r \r This app utilizes the API provided by Fairfax County through the Bus...",
+    "starFiles": [
+      "fairfax_connector.star"
+    ]
+  },
+  {
+    "name": "fantasynamegen",
+    "image": "fantasynamegen/screenshot.png",
+    "md": "fantasynamegen/README.md",
+    "description": "Fantasy Name Generator Applet for Tidbyt Displays a random fantasy or RPG race, class, and name. !Fa...",
+    "starFiles": [
+      "fantasynamegen.star"
+    ]
+  },
+  {
+    "name": "farcasterfollows",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "farcaster_follows.star"
+    ]
+  },
+  {
+    "name": "fbw-flight-stats",
+    "image": "fbw-flight-stats/flybywire_flights.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "flybywire_flights.star"
+    ]
+  },
+  {
+    "name": "fedexcup",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fedex_cup.star"
+    ]
+  },
+  {
+    "name": "feelslike",
+    "image": "feelslike/feelslike.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "feels_like.star"
+    ]
+  },
+  {
+    "name": "fegbasprites",
+    "image": "fegbasprites/fe_gba_sprites.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fe_gba_sprites.star"
+    ]
+  },
+  {
+    "name": "ffxiv_character",
+    "image": "ffxiv_character/ffxiv_character.gif",
+    "md": "ffxiv_character/README.md",
+    "description": "FFXIV Character This app reads Final Fantasy XIV character data from the North American Lodestone. !...",
+    "starFiles": [
+      "ffxiv_character.star"
+    ]
+  },
+  {
+    "name": "fido",
+    "image": "fido/fido.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fido.star"
+    ]
+  },
+  {
+    "name": "filters",
+    "image": "filters/filters.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "filters.star"
+    ]
+  },
+  {
+    "name": "financialtimes",
+    "image": "financialtimes/financial_times.gif",
+    "md": "financialtimes/README.md",
+    "description": "Financial Times News Headlines Financial Times news headlines displays current headline articles (up...",
+    "starFiles": [
+      "financial_times.star"
+    ]
+  },
+  {
+    "name": "finazastocks",
+    "image": "finazastocks/finazastocks.webp",
+    "md": "finazastocks/readme.md",
+    "description": "pixlet render apps/finazastocks/finaza_stocks.star --gif --magnify 10 pixlet serve apps/finazastocks...",
+    "starFiles": [
+      "finaza_stocks.star"
+    ]
+  },
+  {
+    "name": "fineart",
+    "image": "fineart/fineart.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fine_art.star"
+    ]
+  },
+  {
+    "name": "finevent",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "finevent.star"
+    ]
+  },
+  {
+    "name": "fireflies",
+    "image": "fireflies/fireflies-clock.gif",
+    "md": "fireflies/README.md",
+    "description": "Fireflies --- <i>Introduction</i> Fireflies, often referred to as \"nature's tiny lanterns,\" captivat...",
+    "starFiles": [
+      "fireflies.star"
+    ]
+  },
+  {
+    "name": "fireworks",
+    "image": "fireworks/fireworks.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fireworks.star"
+    ]
+  },
+  {
+    "name": "fishbyt",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fishbyt.star"
+    ]
+  },
+  {
+    "name": "fitbitweight",
+    "image": "fitbitweight/fitbitweight.gif",
+    "md": "fitbitweight/readme.md",
+    "description": "FitbitWeight for Tidbyt Displays your weight, and optionally, your body fat percentage or BMI from F...",
+    "starFiles": [
+      "fitbitweight.star"
+    ]
+  },
+  {
+    "name": "fivesomewhere",
+    "image": "fivesomewhere/screenshot.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "five_somewhere.star"
+    ]
+  },
+  {
+    "name": "flags",
+    "image": "flags/flags.webp",
+    "md": "flags/README.md",
+    "description": "Flags! Made by: btjones Displays a country flag on your Tidbyt. The flag can either be a specific co...",
+    "starFiles": [
+      "flags.star"
+    ]
+  },
+  {
+    "name": "flalighthouses",
+    "image": "flalighthouses/fla_lighthouses.webp",
+    "md": "flalighthouses/readme.md",
+    "description": "FLA_Lighthouses for Tidbyt Displays an outline of Florida with faint yellow dots representing Florid...",
+    "starFiles": [
+      "fla_lighthouses.star"
+    ]
+  },
+  {
+    "name": "flightoverhead",
+    "image": "flightoverhead/screenshot.png",
+    "md": "flightoverhead/README.md",
+    "description": "Flight Overhead for Tidbyt Use AirLabs or OpenSky to find the flight overhead a location. By default...",
+    "starFiles": [
+      "flight_overhead.star"
+    ]
+  },
+  {
+    "name": "flightradarfeed",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "flight_radar_feed.star"
+    ]
+  },
+  {
+    "name": "flightsnearby",
+    "image": "flightsnearby/flights_nearby.gif",
+    "md": "flightsnearby/README.md",
+    "description": "Flights Nearby Find the closest flight to your location. Requires a Flight Radar API key from Rapid ...",
+    "starFiles": [
+      "flights_nearby.star"
+    ]
+  },
+  {
+    "name": "flighttracker",
+    "image": "flighttracker/flighttracker.webp",
+    "md": "flighttracker/readme.md",
+    "description": "About This app integrates with the FlightAware API, allowing users to input their FlightAware API ke...",
+    "starFiles": [
+      "flighttracker.star"
+    ]
+  },
+  {
+    "name": "flipclock",
+    "image": "flipclock/flipclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": []
+  },
+  {
+    "name": "flyio",
+    "image": "flyio/error.png",
+    "md": "flyio/README.md",
+    "description": "Fly.io for Tidbyt Displays the current status of the machines running on your Fly.io Apps Set up 1. ...",
+    "starFiles": [
+      "flyio.star"
+    ]
+  },
+  {
+    "name": "flythel",
+    "image": "flythel/CubsL.gif",
+    "md": "flythel/README.md",
+    "description": "Fly The L Borne out of a desire to be notified every time the Cubs lose, here is the app Fly The L! ...",
+    "starFiles": [
+      "flythel.star"
+    ]
+  },
+  {
+    "name": "footballtable",
+    "image": "footballtable/footballtable.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "footballtable.star"
+    ]
+  },
+  {
+    "name": "formula1",
+    "image": "formula1/constructor.gif",
+    "md": "formula1/README.md",
+    "description": "Forumla 1 Formula 1 displays current standings (driver & constructor) & next race info depending on ...",
+    "starFiles": [
+      "formula_1.star"
+    ]
+  },
+  {
+    "name": "fortnitebrnews",
+    "image": "fortnitebrnews/fortnitebrnews.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fortnite_br_news.star"
+    ]
+  },
+  {
+    "name": "fortnitestore",
+    "image": "fortnitestore/fortnite_store.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fortnite_store.star"
+    ]
+  },
+  {
+    "name": "fortnitewins",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fortnite_wins.star"
+    ]
+  },
+  {
+    "name": "foxnews",
+    "image": "foxnews/fox_news.gif",
+    "md": "foxnews/README.md",
+    "description": "Fox News Headlines Fox News headlines displays current headline articles (up to 3) for the selected ...",
+    "starFiles": [
+      "fox_news.star"
+    ]
+  },
+  {
+    "name": "fpltracker",
+    "image": "fpltracker/fpltracker.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fpl_tracker.star"
+    ]
+  },
+  {
+    "name": "frcteamrank",
+    "image": "frcteamrank/frc_team_rank.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "frc_team_rank.star"
+    ]
+  },
+  {
+    "name": "fredscanneralert",
+    "image": "fredscanneralert/fredscanneralert.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fredscanner_alert.star"
+    ]
+  },
+  {
+    "name": "frenchwotd",
+    "image": "frenchwotd/frenchwotd.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "french_wotd.star"
+    ]
+  },
+  {
+    "name": "fridge",
+    "image": "fridge/fridge.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fridge.star"
+    ]
+  },
+  {
+    "name": "friendsquotes",
+    "image": "friendsquotes/screenshot.gif",
+    "md": "friendsquotes/README.md",
+    "description": "Friends Quotes Displays a random quote from the hit TV sitcom, Friends. <img src=\"./screenshot.gif\" ...",
+    "starFiles": [
+      "friends_quotes.star"
+    ]
+  },
+  {
+    "name": "fullybinarytime",
+    "image": "fullybinarytime/fullybinarytime.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fullybinarytime.star"
+    ]
+  },
+  {
+    "name": "fuzzyclock",
+    "image": "fuzzyclock/fuzzyclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "fuzzy_clock.star"
+    ]
+  },
+  {
+    "name": "g35",
+    "image": "g35/g35.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "g35.star"
+    ]
+  },
+  {
+    "name": "gapilotbuddy",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "ga_pilot_buddy.star"
+    ]
+  },
+  {
+    "name": "garageclosed",
+    "image": "garageclosed/garageclosed.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "garageclosed.star"
+    ]
+  },
+  {
+    "name": "garageclosing",
+    "image": "garageclosing/garageclosing.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "garageclosing.star"
+    ]
+  },
+  {
+    "name": "garageopen",
+    "image": "garageopen/garageopen.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "garageopen.star"
+    ]
+  },
+  {
+    "name": "garageopening",
+    "image": "garageopening/garageopening.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "garageopening.star"
+    ]
+  },
+  {
+    "name": "gartnernews",
+    "image": "gartnernews/gartner_news.webp",
+    "md": "gartnernews/readme.md",
+    "description": "Gartner News for Tidbyt Displays the latest headlines from Gartner.com's RSS feed. Gartner, Inc. is ...",
+    "starFiles": [
+      "gartner_news.star"
+    ]
+  },
+  {
+    "name": "gcdailypick",
+    "image": "gcdailypick/gcdailypick.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "gc_daily_pick.star"
+    ]
+  },
+  {
+    "name": "genconcountdown",
+    "image": "genconcountdown/genconcountdown.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "gen_con_countdown.star"
+    ]
+  },
+  {
+    "name": "germanpartypolls",
+    "image": "germanpartypolls/germanpartypolls.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "germanpartypolls.star"
+    ]
+  },
+  {
+    "name": "germantransit",
+    "image": "germantransit/german_transit.gif",
+    "md": "germantransit/README.md",
+    "description": "German Transit German Transit displays upcoming public transportation departures for the selected st...",
+    "starFiles": [
+      "german_transit.star"
+    ]
+  },
+  {
+    "name": "git_commit_humor",
+    "image": "git_commit_humor/git_commit_humor.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "git_commit_humor.star"
+    ]
+  },
+  {
+    "name": "githubactivity",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "github_activity.star"
+    ]
+  },
+  {
+    "name": "githubbadge",
+    "image": "githubbadge/github_badge.webp",
+    "md": "githubbadge/README.md",
+    "description": "GitHub Badge Displays the latest status for a given repository in the design of GitHub's Status Badg...",
+    "starFiles": [
+      "github_badge.star"
+    ]
+  },
+  {
+    "name": "githubrepo",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "github_repo.star"
+    ]
+  },
+  {
+    "name": "githubrepos",
+    "image": "githubrepos/github_repos.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "github_repos.star"
+    ]
+  },
+  {
+    "name": "githubstargazers",
+    "image": "githubstargazers/screenshot.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "github_stargazers.star"
+    ]
+  },
+  {
+    "name": "githubstatus",
+    "image": "githubstatus/github_status.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "github_status.star"
+    ]
+  },
+  {
+    "name": "githubunread",
+    "image": "githubunread/github_unread.gif",
+    "md": "githubunread/README.md",
+    "description": "Github Unread Shows the current number of unread notifications on the linked GitHub. Requires a pers...",
+    "starFiles": [
+      "github_unread.star"
+    ]
+  },
+  {
+    "name": "gitlabissues",
+    "image": "gitlabissues/gitlabissues.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "gitlab_issues.star"
+    ]
+  },
+  {
+    "name": "gitlabpipelinestatus",
+    "image": "gitlabpipelinestatus/gitlab_pipeline.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "gitlab_pipeline.star"
+    ]
+  },
+  {
+    "name": "goldpriceticker",
+    "image": "goldpriceticker/screenshot.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "goldpriceticker.star"
+    ]
+  },
+  {
+    "name": "goodservice",
+    "image": "goodservice/goodservice.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "goodservice.star"
+    ]
+  },
+  {
+    "name": "goosefm",
+    "image": "goosefm/goosefm.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "goose_fm.star"
+    ]
+  },
+  {
+    "name": "gptcolor",
+    "image": "gptcolor/screenshot.png",
+    "md": "gptcolor/README.md",
+    "description": "Colors Generated by GPT3.5 for Tidbyt GPT 3.5 is queried to generate random colors for display every...",
+    "starFiles": [
+      "gpt_color.star"
+    ]
+  },
+  {
+    "name": "gradient",
+    "image": "gradient/gradient.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "gradient.star"
+    ]
+  },
+  {
+    "name": "gradientclock",
+    "image": "gradientclock/gradientclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "gradient_clock.star"
+    ]
+  },
+  {
+    "name": "gradientclock2",
+    "image": "gradientclock2/gradientclock2.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "gradientclock2.star"
+    ]
+  },
+  {
+    "name": "greekletters",
+    "image": "greekletters/greek_letters.webp",
+    "md": "greekletters/readme.md",
+    "description": "Greek Letter Applet for Tidbyt Displays a selected Greek Letter of your choosing, or a random one (d...",
+    "starFiles": [
+      "greek_letters.star"
+    ]
+  },
+  {
+    "name": "guardiannews",
+    "image": "guardiannews/guardiannews.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "guardian_news.star"
+    ]
+  },
+  {
+    "name": "gvbyt",
+    "image": "gvbyt/gvbyt.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "gvbyt.star"
+    ]
+  },
+  {
+    "name": "gw2_fractals",
+    "image": "gw2_fractals/gw2_fractals.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "gw2_fractals.star"
+    ]
+  },
+  {
+    "name": "hackernews",
+    "image": "hackernews/hackernews.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hacker_news.star"
+    ]
+  },
+  {
+    "name": "hackneybindicator",
+    "image": "hackneybindicator/bindicator_1.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hackneybindicator.star"
+    ]
+  },
+  {
+    "name": "haikuboxlinker",
+    "image": "haikuboxlinker/haikuboxlinker.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "haikuboxlinker.star"
+    ]
+  },
+  {
+    "name": "halloweencountdn",
+    "image": "halloweencountdn/halloweencountdn.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "halloween_countdn.star"
+    ]
+  },
+  {
+    "name": "hanukkah",
+    "image": "hanukkah/hanukkah.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hanukkah.star"
+    ]
+  },
+  {
+    "name": "happyhour",
+    "image": "happyhour/happyhour.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "happy_hour.star"
+    ]
+  },
+  {
+    "name": "happypride",
+    "image": "happypride/pride.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "pride.star"
+    ]
+  },
+  {
+    "name": "hashrate",
+    "image": "hashrate/hashrate.webp",
+    "md": "hashrate/README.md",
+    "description": "Plotting the hashrate of Bitcoin Applet for Tidbyt Plotting the hashrate of Bitcoin in a specific ti...",
+    "starFiles": [
+      "hashrate.star"
+    ]
+  },
+  {
+    "name": "hassentity",
+    "image": "hassentity/hass_entity.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hass_entity.star"
+    ]
+  },
+  {
+    "name": "hassentitylist",
+    "image": "hassentitylist/hassentitylist.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hassentitylist.star"
+    ]
+  },
+  {
+    "name": "hassgraph",
+    "image": "hassgraph/hassgraph.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hass_graph.star"
+    ]
+  },
+  {
+    "name": "hassmedia",
+    "image": "hassmedia/hassmedia.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hassmedia.star"
+    ]
+  },
+  {
+    "name": "hasssolar",
+    "image": "hasssolar/frame_0.png",
+    "md": "hasssolar/README.md",
+    "description": "Solar Monitoring Applet using Home Assistant for Tidbyt About Displays real-time solar panel product...",
+    "starFiles": [
+      "hass_solar.star"
+    ]
+  },
+  {
+    "name": "helldivers2",
+    "image": "helldivers2/helldivers2.webp",
+    "md": "helldivers2/README.md",
+    "description": "Helldivers 2 Overview This app shows the current number of players for the game Helldivers 2. API De...",
+    "starFiles": [
+      "helldivers_2.star"
+    ]
+  },
+  {
+    "name": "hexcolorclock",
+    "image": "hexcolorclock/hex_color_clock.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hex_color_clock.star"
+    ]
+  },
+  {
+    "name": "hexdailystats",
+    "image": "hexdailystats/screenshot.png",
+    "md": "hexdailystats/README.md",
+    "description": "HEX Daily Stats Applet for Tidbyt Displays the current HEX daily stats (USD Price, Payout per T-Shar...",
+    "starFiles": [
+      "hex_daily_stats.star"
+    ]
+  },
+  {
+    "name": "hieroglyphs",
+    "image": "hieroglyphs/A1.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hieroglyphs.star"
+    ]
+  },
+  {
+    "name": "hilbertclock",
+    "image": "hilbertclock/hilbertclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hilbert_clock.star"
+    ]
+  },
+  {
+    "name": "holidays",
+    "image": "holidays/holidays.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "holidays.star"
+    ]
+  },
+  {
+    "name": "homefiniti",
+    "image": "homefiniti/homefiniti.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "homefiniti.star"
+    ]
+  },
+  {
+    "name": "homerhiding",
+    "image": "homerhiding/homerhiding.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "homer_hiding.star"
+    ]
+  },
+  {
+    "name": "houseofcommons",
+    "image": "houseofcommons/1997.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "house_of_commons.star"
+    ]
+  },
+  {
+    "name": "houstonmetro",
+    "image": "houstonmetro/houstonmetro.webp",
+    "md": "houstonmetro/README.md",
+    "description": "Welcome to the Houston Metro App! This app uses the Houston Metro API (https://api-portal.ridemetro....",
+    "starFiles": [
+      "houstonmetro.star"
+    ]
+  },
+  {
+    "name": "howoldami",
+    "image": "howoldami/howoldami.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "howoldami.star"
+    ]
+  },
+  {
+    "name": "hrbfc",
+    "image": "hrbfc/hrbfc.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hrbfc.star"
+    ]
+  },
+  {
+    "name": "hubblelive",
+    "image": null,
+    "md": "hubblelive/README.md",
+    "description": "<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Tem...",
+    "starFiles": [
+      "hubble_live.star"
+    ]
+  },
+  {
+    "name": "hurricanetracker",
+    "image": "hurricanetracker/hurricanetracker.webp",
+    "md": "hurricanetracker/readme.md",
+    "description": "Hurricane Tracking Applet for Tidbyt Display the latest information from the National Hurricane Cent...",
+    "starFiles": [
+      "hurricanetracker.star"
+    ]
+  },
+  {
+    "name": "hvvdepartures",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "hvv_departures.star"
+    ]
+  },
+  {
+    "name": "iconote",
+    "image": "iconote/iconote.webp",
+    "md": "iconote/README.md",
+    "description": "IcoNote --- This Tidbyt app lets you display a vertical scrolling message with one of the 75 predefi...",
+    "starFiles": [
+      "iconote.star"
+    ]
+  },
+  {
+    "name": "idlegardener",
+    "image": "idlegardener/idlegardener.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "idle_gardener.star"
+    ]
+  },
+  {
+    "name": "ifpaevents",
+    "image": null,
+    "md": "ifpaevents/README.md",
+    "description": "IFPA Events Display a list of upcoming International Flipper Pinball Association events based on loc...",
+    "starFiles": [
+      "ifpaevents.star"
+    ]
+  },
+  {
+    "name": "ifparank",
+    "image": "ifparank/ifparank.gif",
+    "md": "ifparank/README.md",
+    "description": "IFPA Rank Displays a pinball player's world ranking according to the Internation Flipper Pinball Ass...",
+    "starFiles": [
+      "ifparank.star"
+    ]
+  },
+  {
+    "name": "ilt20cricket",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "ilt20_cricket.star"
+    ]
+  },
+  {
+    "name": "incomecounter",
+    "image": "incomecounter/incomecounter.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "income_counter.star"
+    ]
+  },
+  {
+    "name": "indego",
+    "image": "indego/indego.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "indego.star"
+    ]
+  },
+  {
+    "name": "indegostations",
+    "image": "indegostations/indegostations.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "indego_stations.star"
+    ]
+  },
+  {
+    "name": "indexticker",
+    "image": "indexticker/indexticker.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "index_ticker.star"
+    ]
+  },
+  {
+    "name": "indianews",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "india_news.star"
+    ]
+  },
+  {
+    "name": "indycar",
+    "image": "indycar/Detroit.png",
+    "md": "indycar/README.md",
+    "description": "Indycar Next Race and Standings Indycar displays next race details and current standings details for...",
+    "starFiles": [
+      "indy_car.star"
+    ]
+  },
+  {
+    "name": "inseason",
+    "image": "inseason/inseason.webp",
+    "md": "inseason/readme.md",
+    "description": "InSeason Applet for Tidbyt Displays foods that are in season for your part of the United States main...",
+    "starFiles": [
+      "inseason.star"
+    ]
+  },
+  {
+    "name": "instagram",
+    "image": "instagram/instagram.webp",
+    "md": "instagram/README.md",
+    "description": "Instagram Overview This app shows an Instagram user's number of followers, extracted from the user's...",
+    "starFiles": [
+      "instagram.star"
+    ]
+  },
+  {
+    "name": "ipl",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "ipl.star"
+    ]
+  },
+  {
+    "name": "isaacdance",
+    "image": "isaacdance/isaacdance.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "isaac_dance.star"
+    ]
+  },
+  {
+    "name": "isitchristmas",
+    "image": "isitchristmas/isitchristmas.webp",
+    "md": "isitchristmas/readme.md",
+    "description": "Is It Christmas? A single usage app that tells users is it or is it not Christmas. !Christmas !Not C...",
+    "starFiles": [
+      "is_it_christmas.star"
+    ]
+  },
+  {
+    "name": "islamicprayer",
+    "image": "islamicprayer/islamic_prayer.gif",
+    "md": "islamicprayer/README.md",
+    "description": "Islamic prayer times A display on prayer times for the day. !Islamic prayer times Special Thank You ...",
+    "starFiles": [
+      "islamic_prayer.star"
+    ]
+  },
+  {
+    "name": "iss",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "iss.star"
+    ]
+  },
+  {
+    "name": "isslocation",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "iss_location.star"
+    ]
+  },
+  {
+    "name": "isstracker",
+    "image": "isstracker/iss-logo.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "iss_tracker.star"
+    ]
+  },
+  {
+    "name": "jacket",
+    "image": "jacket/jacket.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "jacket.star"
+    ]
+  },
+  {
+    "name": "javelexi",
+    "image": "javelexi/javelexi.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "javelexi.star"
+    ]
+  },
+  {
+    "name": "jeopardy",
+    "image": "jeopardy/jeopardy.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "jeopardy.star"
+    ]
+  },
+  {
+    "name": "jokesjokeapi",
+    "image": "jokesjokeapi/jokesjokeapi.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "jokes_jokeapi.star"
+    ]
+  },
+  {
+    "name": "jsondisplay",
+    "image": "jsondisplay/json_display.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "json_display.star"
+    ]
+  },
+  {
+    "name": "justfortoday",
+    "image": "justfortoday/just_for_today.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "just_for_today.star"
+    ]
+  },
+  {
+    "name": "kexplaying",
+    "image": "kexplaying/kexplaying.webp",
+    "md": "kexplaying/README.md",
+    "description": "KEXPlaying KEXPlaying displays the current song and artist information playing on KEXP 90.3 FM and k...",
+    "starFiles": [
+      "kexplaying.star"
+    ]
+  },
+  {
+    "name": "kickstarter",
+    "image": "kickstarter/screenshot.png",
+    "md": "kickstarter/README.md",
+    "description": "Kickstarter Applet for Tidbyt Displays a Kickstarter project status with the total funding raised an...",
+    "starFiles": [
+      "kickstarter.star"
+    ]
+  },
+  {
+    "name": "kielferry",
+    "image": null,
+    "md": "kielferry/README.md",
+    "description": "Kiel Harbor Ferry Departure Times Applet for Tidbyt Displays the next Kiel harbor ferry departure an...",
+    "starFiles": [
+      "kiel_ferry.star"
+    ]
+  },
+  {
+    "name": "knmialert",
+    "image": null,
+    "md": "knmialert/README.md",
+    "description": "KNMIalert Applet for Tidbyt Only displays active live weather alerts by KNMI for The Netherlands. If...",
+    "starFiles": [
+      "knmialert.star"
+    ]
+  },
+  {
+    "name": "koppscustard",
+    "image": "koppscustard/koppscustard.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "kopps_custard.star"
+    ]
+  },
+  {
+    "name": "kqac",
+    "image": "kqac/kqac.webp",
+    "md": "kqac/README.md",
+    "description": "KQAC (All Classical Portland) Show what's currently playing on All Classical Portland on your Tidbyt...",
+    "starFiles": [
+      "kqac.star"
+    ]
+  },
+  {
+    "name": "la_metro",
+    "image": "la_metro/la_metro.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "la_metro.star"
+    ]
+  },
+  {
+    "name": "lametrostop",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "la_metro_stop.star"
+    ]
+  },
+  {
+    "name": "langtonsant",
+    "image": "langtonsant/langtonsant.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "langtons_ant.star"
+    ]
+  },
+  {
+    "name": "lastfm",
+    "image": "lastfm/last_fm.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "last_fm.star"
+    ]
+  },
+  {
+    "name": "lastfmstats",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "lastfmstats.star"
+    ]
+  },
+  {
+    "name": "launchcountdown",
+    "image": "launchcountdown/launchcountdown.webp",
+    "md": "launchcountdown/readme.md",
+    "description": "Launch Countdown Applet for Tidbyt Displays the next rocketlaunch in the world based on the data pro...",
+    "starFiles": [
+      "launchcountdown.star"
+    ]
+  },
+  {
+    "name": "lax_departures",
+    "image": "lax_departures/lax_departures.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "lax_departures.star"
+    ]
+  },
+  {
+    "name": "leaguechamps",
+    "image": "leaguechamps/league_champs.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "league_champs.star"
+    ]
+  },
+  {
+    "name": "leetcodestats",
+    "image": "leetcodestats/screenshot.png",
+    "md": "leetcodestats/README.md",
+    "description": "LeetCode stats for Tidbyt Displays your LeetCode stats in a nice way. !LeetCode stats for Tidbyt",
+    "starFiles": [
+      "leetcodestats.star"
+    ]
+  },
+  {
+    "name": "letterboxd",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "letterboxd.star"
+    ]
+  },
+  {
+    "name": "librenmsalerts",
+    "image": "librenmsalerts/librenmsalerts.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "librenms_alerts.star"
+    ]
+  },
+  {
+    "name": "librenmsdevices",
+    "image": "librenmsdevices/librenmsdevices.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "librenms_devices.star"
+    ]
+  },
+  {
+    "name": "lichesscorrespond",
+    "image": "lichesscorrespond/lichesscorrespond.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "lichesscorrespond.star"
+    ]
+  },
+  {
+    "name": "life",
+    "image": "life/life.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "life.star"
+    ]
+  },
+  {
+    "name": "lifeclock",
+    "image": "lifeclock/lifeclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "life_clock.star"
+    ]
+  },
+  {
+    "name": "lifecounter",
+    "image": "lifecounter/life_counter.gif",
+    "md": "lifecounter/README.md",
+    "description": "Life Counter > How long do you have left? If you don't feel overwhelmed enough by your own mortality...",
+    "starFiles": [
+      "life_counter.star"
+    ]
+  },
+  {
+    "name": "lifxlights",
+    "image": "lifxlights/lifx_lights.gif",
+    "md": "lifxlights/README.md",
+    "description": "LIFX Lights Overview LIFX is a recognized brand of multi-colored and wi-fi enabled smart bulbs. It o...",
+    "starFiles": [
+      "lifx_lights.star"
+    ]
+  },
+  {
+    "name": "lightningnode",
+    "image": "lightningnode/lightningnode.webp",
+    "md": "lightningnode/README.md",
+    "description": "LightningNode Applet for Tidbyt Displays the Bitcoin Lightning Network statistics in a specific time...",
+    "starFiles": [
+      "lightningnode.star"
+    ]
+  },
+  {
+    "name": "lionsbrgstatus",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "lions_gate_status.star"
+    ]
+  },
+  {
+    "name": "lirr",
+    "image": "lirr/lirr.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "lirr.star"
+    ]
+  },
+  {
+    "name": "literatureclock",
+    "image": "literatureclock/literatureclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "literature_clock.star"
+    ]
+  },
+  {
+    "name": "liveontwitch",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "live_on_twitch.star"
+    ]
+  },
+  {
+    "name": "loanpayment",
+    "image": "loanpayment/loan_payment.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "loan_payment.star"
+    ]
+  },
+  {
+    "name": "lobsterfacts",
+    "image": "lobsterfacts/lobster_facts.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "lobster_facts.star"
+    ]
+  },
+  {
+    "name": "localtides",
+    "image": "localtides/local_tides_harmonic.jpg",
+    "md": "localtides/README.md",
+    "description": "Local Tides --- <i>Introduction</i> This app uses data from the NOAA website to render a 24-hour tid...",
+    "starFiles": [
+      "local_tides.star"
+    ]
+  },
+  {
+    "name": "lolstats",
+    "image": "lolstats/lol_stats.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "lol_stats.star"
+    ]
+  },
+  {
+    "name": "londonbusstop",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "london_bus_stop.star"
+    ]
+  },
+  {
+    "name": "lordoftherings",
+    "image": "lordoftherings/screenshot.png",
+    "md": "lordoftherings/README.md",
+    "description": "Lord of the Rings Random Quote Generator Displays a randomly chosen quote from the original Lord of ...",
+    "starFiles": [
+      "lordoftherings.star"
+    ]
+  },
+  {
+    "name": "loterias",
+    "image": "loterias/loterias.webp",
+    "md": "loterias/README.md",
+    "description": "Loterias do Brasil Overview The Loteria is the official Brazilian lottery. This app displays the est...",
+    "starFiles": [
+      "loterias.star"
+    ]
+  },
+  {
+    "name": "lovelandwebcams",
+    "image": "lovelandwebcams/lovelandwebcams.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "loveland_webcams.star"
+    ]
+  },
+  {
+    "name": "madisonmetrobus",
+    "image": "madisonmetrobus/madison_metro_bus.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "madison_metro_bus.star"
+    ]
+  },
+  {
+    "name": "mantle",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mantle.star"
+    ]
+  },
+  {
+    "name": "marioandyoshi",
+    "image": "marioandyoshi/marioandyoshi.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mario_and_yoshi.star"
+    ]
+  },
+  {
+    "name": "marketstack",
+    "image": "marketstack/marketstack.gif",
+    "md": "marketstack/README.md",
+    "description": "Stock Value as plot Price Applet for Tidbyt Allows you to track the value of a stock as plot with hi...",
+    "starFiles": [
+      "marketstack.star"
+    ]
+  },
+  {
+    "name": "marsclock",
+    "image": "marsclock/marsclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mars_clock.star"
+    ]
+  },
+  {
+    "name": "martamap",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "marta_map.star"
+    ]
+  },
+  {
+    "name": "martini",
+    "image": "martini/martini.webp",
+    "md": "martini/readme.md",
+    "description": "Martini Applet for Tidbyt This app asks you your martini preferences, then displays the best way to ...",
+    "starFiles": [
+      "martini.star"
+    ]
+  },
+  {
+    "name": "marvelfacts",
+    "image": "marvelfacts/marvelfacts.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "marvel_facts.star"
+    ]
+  },
+  {
+    "name": "marveloftheday",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "marvel_of_the_day.star"
+    ]
+  },
+  {
+    "name": "mastodonfollows",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mastodon_follows.star"
+    ]
+  },
+  {
+    "name": "mathclock",
+    "image": "mathclock/mathclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "math_clock.star"
+    ]
+  },
+  {
+    "name": "mayacalendar",
+    "image": "mayacalendar/castillo.png",
+    "md": "mayacalendar/README.md",
+    "description": "Maya Calendar Displays today’s date in the calendar systems used by the ancient Maya civilization of...",
+    "starFiles": [
+      "maya_calendar.star"
+    ]
+  },
+  {
+    "name": "mayaglyphs",
+    "image": "mayaglyphs/0764.01.gif",
+    "md": null,
+    "description": null,
+    "starFiles": []
+  },
+  {
+    "name": "mayoclinicnews",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mayo_clinic_news.star"
+    ]
+  },
+  {
+    "name": "maze",
+    "image": "maze/maze.gif",
+    "md": "maze/README.md",
+    "description": "Maze Applet for Tidbyt Draws a unique maze and then shows the interactive search for a solution to t...",
+    "starFiles": [
+      "maze.star"
+    ]
+  },
+  {
+    "name": "maze_generators",
+    "image": "maze_generators/maze_generators.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "maze_generators.star"
+    ]
+  },
+  {
+    "name": "mbta",
+    "image": "mbta/mbta.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mbta.star"
+    ]
+  },
+  {
+    "name": "mbtanewtrains",
+    "image": "mbtanewtrains/large.webp",
+    "md": "mbtanewtrains/README.md",
+    "description": "MBTA New Trains Pulls live train data to display the real time location of the _new_ MBTA train cars...",
+    "starFiles": [
+      "mbta_new_trains.star"
+    ]
+  },
+  {
+    "name": "mctstracker",
+    "image": "mctstracker/mctstracker.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mcts_tracker.star"
+    ]
+  },
+  {
+    "name": "mealviewer",
+    "image": "mealviewer/mealviewer.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mealviewer.star"
+    ]
+  },
+  {
+    "name": "meeting_stats",
+    "image": "meeting_stats/meeting_stats.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "meeting_stats.star"
+    ]
+  },
+  {
+    "name": "meh",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "meh.star"
+    ]
+  },
+  {
+    "name": "melbournebuses",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "melbourne_buses.star"
+    ]
+  },
+  {
+    "name": "melbournetrains",
+    "image": "melbournetrains/melbourne_trains.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "melbourne_trains.star"
+    ]
+  },
+  {
+    "name": "melbournetrams",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "melbourne_trams.star"
+    ]
+  },
+  {
+    "name": "mempool",
+    "image": "mempool/mempool.webp",
+    "md": "mempool/README.md",
+    "description": "Mempool Applet for Tidbyt Display the current mempool fee statistics in the orange block on the left...",
+    "starFiles": [
+      "mempool.star"
+    ]
+  },
+  {
+    "name": "menscricket",
+    "image": "menscricket/live_match.gif",
+    "md": "menscricket/README.md",
+    "description": "Live cricket scores on your Tidbyt The app lets you select a team and display score of a live cricke...",
+    "starFiles": [
+      "mens_cricket.star"
+    ]
+  },
+  {
+    "name": "merakiusage",
+    "image": "merakiusage/merakiusage.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "meraki_usage.star"
+    ]
+  },
+  {
+    "name": "mercuryretrograde",
+    "image": "mercuryretrograde/mercuryretrograde.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mercuryretrograde.star"
+    ]
+  },
+  {
+    "name": "metar",
+    "image": "metar/metar.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "metar.star"
+    ]
+  },
+  {
+    "name": "meteireann",
+    "image": "meteireann/meteireann.webp",
+    "md": "meteireann/README.md",
+    "description": "Met Eireann Tidbyt app Pulls from Met Eireann's Forecast API to display a weather app on Tidbyt. Met...",
+    "starFiles": [
+      "met_eireann.star"
+    ]
+  },
+  {
+    "name": "mhkyscores",
+    "image": "mhkyscores/screenshot.png",
+    "md": "mhkyscores/README.md",
+    "description": "NCCAB Scores for Tidbyt Displays live NCAAB scores and gambling odds for upcoming games. Updated eve...",
+    "starFiles": [
+      "mhky_scores.star"
+    ]
+  },
+  {
+    "name": "milbscores",
+    "image": "milbscores/milbscores.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "milb_scores.star"
+    ]
+  },
+  {
+    "name": "militarynews",
+    "image": "militarynews/military_news.webp",
+    "md": "militarynews/README.md",
+    "description": "Military News for Tidbyt Displays some recent headlines for the selected branch of the military, or ...",
+    "starFiles": [
+      "military_news.star"
+    ]
+  },
+  {
+    "name": "militaryranks",
+    "image": "militaryranks/military_ranks.webp",
+    "md": "militaryranks/readme.md",
+    "description": "Military Ranks Applet for Tidbyt Display your Military Rank on your Tidbyt with your name, or use th...",
+    "starFiles": [
+      "military_ranks.star"
+    ]
+  },
+  {
+    "name": "mindthegap",
+    "image": "mindthegap/mind_the_gap.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mind_the_gap.star"
+    ]
+  },
+  {
+    "name": "minecraftart",
+    "image": "minecraftart/minecraftart.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "minecraft_art.star"
+    ]
+  },
+  {
+    "name": "minecraftrealms",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "minecraft_realms.star"
+    ]
+  },
+  {
+    "name": "minecraftserver",
+    "image": null,
+    "md": "minecraftserver/README.md",
+    "description": "Minecraft Server Display Applet for Tidbyt Display current minecraft server logo and online/max play...",
+    "starFiles": [
+      "minecraft_server.star"
+    ]
+  },
+  {
+    "name": "minionsclapping",
+    "image": "minionsclapping/minionsclapping.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "minions_clapping.star"
+    ]
+  },
+  {
+    "name": "mlbdivstandings",
+    "image": "mlbdivstandings/mlbdivstandings.webp",
+    "md": "mlbdivstandings/README.md",
+    "description": "MLB Division Standings Stay up to date on your favorite MLB division with this app displaying the di...",
+    "starFiles": [
+      "mlbdivstandings.star"
+    ]
+  },
+  {
+    "name": "mlbleaders",
+    "image": "mlbleaders/mlbleaders.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mlb_leaders.star"
+    ]
+  },
+  {
+    "name": "mlbmagicnumber",
+    "image": "mlbmagicnumber/mlbmagicnumber.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mlb_magic_number.star"
+    ]
+  },
+  {
+    "name": "mlbnextgames",
+    "image": "mlbnextgames/mlb_next_games.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mlb_next_games.star"
+    ]
+  },
+  {
+    "name": "mlbscores",
+    "image": "mlbscores/screenshot.png",
+    "md": "mlbscores/README.md",
+    "description": "MLB Scores for Tidbyt Displays live MLB scores and gambling odds for upcoming games. Updated every 2...",
+    "starFiles": [
+      "mlb_scores.star"
+    ]
+  },
+  {
+    "name": "mlbstandings",
+    "image": "mlbstandings/screenshot.png",
+    "md": "mlbstandings/README.md",
+    "description": "MLB Standings for Tidbyt Displays live MLB standings by division. !MLB Standings for Tidbyt",
+    "starFiles": [
+      "mlb_standings.star"
+    ]
+  },
+  {
+    "name": "mlbwildcardrace",
+    "image": "mlbwildcardrace/mlbwildcardrace.webp",
+    "md": "mlbwildcardrace/README.md",
+    "description": "MLB Wild Card Race for Tidbyt Display the MLB wild card contenders for the current season. Choose ei...",
+    "starFiles": [
+      "mlb_wildcard_race.star"
+    ]
+  },
+  {
+    "name": "mlct20",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mlc_t20.star"
+    ]
+  },
+  {
+    "name": "mlsscores",
+    "image": "mlsscores/screenshot.png",
+    "md": "mlsscores/README.md",
+    "description": "MLS Scores for Tidbyt Displays live MLS scores and gambling odds for upcoming games. Updated every 2...",
+    "starFiles": [
+      "mls_scores.star"
+    ]
+  },
+  {
+    "name": "mnlightrail",
+    "image": "mnlightrail/mnlightrail.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mn_light_rail.star"
+    ]
+  },
+  {
+    "name": "mnmetrotransit",
+    "image": "mnmetrotransit/mnmetrotransit.webp",
+    "md": "mnmetrotransit/README.md",
+    "description": "This new app is the \"MN Metro Transit\" app as it encompasses everything within the Minneapolis - St....",
+    "starFiles": [
+      "mn_metro_transit.star"
+    ]
+  },
+  {
+    "name": "mobygames",
+    "image": null,
+    "md": "mobygames/README.md",
+    "description": "MobyGames ================== This app uses the MobyGames API to select a random game from the MobyGa...",
+    "starFiles": [
+      "moby_games.star"
+    ]
+  },
+  {
+    "name": "mondrianclock",
+    "image": "mondrianclock/mondrianclock.webp",
+    "md": "mondrianclock/README.md",
+    "description": "Piet Mondrian-inspired clock for Tidbyt Displays the time with a beautiful, unique composition De St...",
+    "starFiles": [
+      "mondrianclock.star"
+    ]
+  },
+  {
+    "name": "moneymade",
+    "image": "moneymade/moneymade.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "money_made.star"
+    ]
+  },
+  {
+    "name": "mongodbnotify",
+    "image": "mongodbnotify/mongodbnotify.webp",
+    "md": "mongodbnotify/README.md",
+    "description": "mongodb-notify NOTICE MongoDB announced the end of the Data API interface. It will be September 30, ...",
+    "starFiles": [
+      "mongodb_notify.star"
+    ]
+  },
+  {
+    "name": "moonphase",
+    "image": "moonphase/moon_phase.gif",
+    "md": "moonphase/README.md",
+    "description": "Moon Phase Applet for Tidbyt Displays the current phase of the moon, where the angle of the crescent...",
+    "starFiles": [
+      "moon_phase.star"
+    ]
+  },
+  {
+    "name": "moretransit",
+    "image": "moretransit/moretransit.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "moretransit.star"
+    ]
+  },
+  {
+    "name": "motogp",
+    "image": "motogp/motogp.webp",
+    "md": "motogp/README.md",
+    "description": "MotoGP standings and schedules on your Tidbyt App lets you display the next event time in your local...",
+    "starFiles": [
+      "motogp.star"
+    ]
+  },
+  {
+    "name": "moviechallenge",
+    "image": "moviechallenge/movie_challenge.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "movie_challenge.star"
+    ]
+  },
+  {
+    "name": "movienight",
+    "image": "movienight/screenshot.png",
+    "md": "movienight/README.md",
+    "description": "Movie Night Marquee Display for TidByt Displays a marquee for a movie title along with a countdown t...",
+    "starFiles": [
+      "movie_night.star"
+    ]
+  },
+  {
+    "name": "moviequotes",
+    "image": "moviequotes/screenshot.png",
+    "md": "moviequotes/README.md",
+    "description": "Top 100 Movie Quotes A random movie quote from AFI's top 100 movie quotes of all time. !Top 100 Movi...",
+    "starFiles": [
+      "movie_quotes.star"
+    ]
+  },
+  {
+    "name": "msteamsstatus",
+    "image": "msteamsstatus/screenshot.png",
+    "md": "msteamsstatus/README.md",
+    "description": "msteamsstatus\r \r Display your Microsoft Teams presence information on your Tidbyt to let coworkers k...",
+    "starFiles": [
+      "ms_teams_status.star"
+    ]
+  },
+  {
+    "name": "mtabus",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mta_bus.star"
+    ]
+  },
+  {
+    "name": "mtarailroadsign",
+    "image": "mtarailroadsign/mtarailroadsign.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mta_railroad_sign.star"
+    ]
+  },
+  {
+    "name": "mtatraintime",
+    "image": "mtatraintime/mtatraintime.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mtatraintime.star"
+    ]
+  },
+  {
+    "name": "mtgdiscover",
+    "image": "mtgdiscover/mtgdiscover.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mtg_discover.star"
+    ]
+  },
+  {
+    "name": "mtgscryone",
+    "image": "mtgscryone/mtg_scry_one.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "mtg_scry_one.star"
+    ]
+  },
+  {
+    "name": "multicountdown",
+    "image": "multicountdown/multicountdown.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "multicountdown.star"
+    ]
+  },
+  {
+    "name": "multipleimages",
+    "image": "multipleimages/multipleimages.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "multiple_images.star"
+    ]
+  },
+  {
+    "name": "munidepartures",
+    "image": "munidepartures/icon.png",
+    "md": "munidepartures/README.md",
+    "description": "Muni Departures Display real-time San Francisco Muni bus and rail departure times on your Tidbyt. !M...",
+    "starFiles": [
+      "muni_departures.star"
+    ]
+  },
+  {
+    "name": "murphyusagas",
+    "image": "murphyusagas/murphygasclosed.jpg",
+    "md": "murphyusagas/README.md",
+    "description": "Murphy USA Gas Applet  Displays current gas prices for a selected Murphy USA gas station. Features U...",
+    "starFiles": [
+      "murphy_usa_gas.star"
+    ]
+  },
+  {
+    "name": "mvv",
+    "image": "mvv/screenshot.png",
+    "md": "mvv/README.md",
+    "description": "MVV Departure Times for Tidbyt This app shows train/tram/bus departure times at a selected stop insi...",
+    "starFiles": [
+      "mvv.star"
+    ]
+  },
+  {
+    "name": "nascarnextrace",
+    "image": "nascarnextrace/nascarnextrace-mfg.gif",
+    "md": "nascarnextrace/README.md",
+    "description": "NASCAR Next Race NASCAR Next Race displays next race details, current standings details or playoff d...",
+    "starFiles": [
+      "nascarnextrace.star"
+    ]
+  },
+  {
+    "name": "natdex",
+    "image": "natdex/natdex.webp",
+    "md": "natdex/README.md",
+    "description": "Simple National Pokédex Display a random Pokémon with its name and dex number from Generations I - V...",
+    "starFiles": [
+      "natdex.star"
+    ]
+  },
+  {
+    "name": "nationalParks",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "national_parks.star"
+    ]
+  },
+  {
+    "name": "nationalday",
+    "image": "nationalday/nationalday.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nationalday.star"
+    ]
+  },
+  {
+    "name": "nationallottery",
+    "image": "nationallottery/national_lottery.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "national_lottery.star"
+    ]
+  },
+  {
+    "name": "nationalrail",
+    "image": "nationalrail/compact.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "national_rail.star"
+    ]
+  },
+  {
+    "name": "nationaltoday",
+    "image": "nationaltoday/nationaltoday.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nationaltoday.star"
+    ]
+  },
+  {
+    "name": "nauticalflags",
+    "image": "nauticalflags/nauticalflags.webp",
+    "md": "nauticalflags/README.md",
+    "description": "Nautical Flags for Tidbyt Displays Nautical Flags. You can pick from displaying random maritime 2 an...",
+    "starFiles": [
+      "nauticalflags.star"
+    ]
+  },
+  {
+    "name": "nbascores",
+    "image": "nbascores/screenshot.png",
+    "md": "nbascores/README.md",
+    "description": "NBA Scores for Tidbyt Displays live NBA scores and gambling odds for upcoming games. Updated every 2...",
+    "starFiles": [
+      "nba_scores.star"
+    ]
+  },
+  {
+    "name": "nbastandings",
+    "image": "nbastandings/screenshot.png",
+    "md": "nbastandings/README.md",
+    "description": "NBA Standings for Tidbyt Displays live NBA standings by division. !NBA Standings for Tidbyt",
+    "starFiles": [
+      "nba_standings.star"
+    ]
+  },
+  {
+    "name": "nbastats",
+    "image": "nbastats/nba_stats.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nba_stats.star"
+    ]
+  },
+  {
+    "name": "ncaabscores",
+    "image": "ncaabscores/screenshot.png",
+    "md": "ncaabscores/README.md",
+    "description": "NCCAB Scores for Tidbyt Displays live NCAAB scores and gambling odds for upcoming games. Updated eve...",
+    "starFiles": [
+      "ncaab_scores.star"
+    ]
+  },
+  {
+    "name": "ncaafscores",
+    "image": "ncaafscores/screenshot.png",
+    "md": "ncaafscores/README.md",
+    "description": "NCCAF Scores for Tidbyt Displays live NCAAF scores and gambling odds for upcoming games. Updated eve...",
+    "starFiles": [
+      "ncaaf_scores.star"
+    ]
+  },
+  {
+    "name": "ncaafstandings",
+    "image": "ncaafstandings/screenshot.png",
+    "md": "ncaafstandings/README.md",
+    "description": "NCCAF Standings for Tidbyt Displays live NCAAF standings by conference. !NCAAF Standings for Tidbyt",
+    "starFiles": [
+      "ncaaf_standings.star"
+    ]
+  },
+  {
+    "name": "ncaamscores",
+    "image": "ncaamscores/screenshot.png",
+    "md": "ncaamscores/README.md",
+    "description": "NCAA Mens Basketball Scores for Tidbyt Displays live NCAA Mens Basketball scores and gambling odds f...",
+    "starFiles": [
+      "ncaam_scores.star"
+    ]
+  },
+  {
+    "name": "ncaamstandings",
+    "image": "ncaamstandings/screenshot.png",
+    "md": "ncaamstandings/README.md",
+    "description": "NCCAM Standings for Tidbyt Displays live NCAAM standings by conference. !NCAAM Standings for Tidbyt",
+    "starFiles": [
+      "ncaam_standings.star"
+    ]
+  },
+  {
+    "name": "ncaasoftball",
+    "image": "ncaasoftball/ncaasoftball.webp",
+    "md": "ncaasoftball/README.md",
+    "description": "NCAA Softball Long awaited and finally here is your NCAA Softball app! Follow your favorite school o...",
+    "starFiles": [
+      "ncaa_softball.star"
+    ]
+  },
+  {
+    "name": "ncaawscores",
+    "image": "ncaawscores/screenshot.png",
+    "md": "ncaawscores/README.md",
+    "description": "NCAA Womens Basketball Scores for Tidbyt Displays live NCAA Womens Basketball scores and gambling od...",
+    "starFiles": [
+      "ncaaw_scores.star"
+    ]
+  },
+  {
+    "name": "ncaawstandings",
+    "image": "ncaawstandings/screenshot.png",
+    "md": "ncaawstandings/README.md",
+    "description": "NCCAW Standings for Tidbyt Displays live NCAAW standings by conference. !NCAAW Standings for Tidbyt",
+    "starFiles": [
+      "ncaaw_standings.star"
+    ]
+  },
+  {
+    "name": "nearearthobjs",
+    "image": "nearearthobjs/nearearthobjs.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "near_earth_objs.star"
+    ]
+  },
+  {
+    "name": "neotrack",
+    "image": null,
+    "md": "neotrack/README.md",
+    "description": "NEOTrack - Near Earth Object Tracker Shows the closest object on approach to Earth today according t...",
+    "starFiles": [
+      "neotrack.star"
+    ]
+  },
+  {
+    "name": "neotracker",
+    "image": "neotracker/neo_tracker.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "neo_tracker.star"
+    ]
+  },
+  {
+    "name": "nesclock",
+    "image": "nesclock/nesclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nes_clock.star"
+    ]
+  },
+  {
+    "name": "nesquotes",
+    "image": "nesquotes/nesquotes.webp",
+    "md": "nesquotes/README.md",
+    "description": "NES Quotes Applet for TidByt Displays randomized quotes from Nintendo Entertainment System games alo...",
+    "starFiles": [
+      "nes_quotes.star"
+    ]
+  },
+  {
+    "name": "netatmo",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "netatmo.star"
+    ]
+  },
+  {
+    "name": "netflixtop10",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "netflix_top_10.star"
+    ]
+  },
+  {
+    "name": "newapps",
+    "image": "newapps/new_apps.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "new_apps.star"
+    ]
+  },
+  {
+    "name": "newjerseypath",
+    "image": "newjerseypath/newjerseypath.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "new_jersey_path.star"
+    ]
+  },
+  {
+    "name": "news",
+    "image": "news/news.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "news.star"
+    ]
+  },
+  {
+    "name": "newsmix",
+    "image": "newsmix/news_mix.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "news_mix.star"
+    ]
+  },
+  {
+    "name": "newyearscountdown",
+    "image": "newyearscountdown/new_years_countdown.gif",
+    "md": "newyearscountdown/README.md",
+    "description": "New Years Countdown Displays the days left until New Year's with Fireworks. !screenshot",
+    "starFiles": [
+      "new_years_countdown.star"
+    ]
+  },
+  {
+    "name": "nextdns",
+    "image": "nextdns/screenshot.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nextdns.star"
+    ]
+  },
+  {
+    "name": "nextevent",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "next_event.star"
+    ]
+  },
+  {
+    "name": "nextufc",
+    "image": "nextufc/nextufc.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "next_ufc.star"
+    ]
+  },
+  {
+    "name": "nfldivstandings",
+    "image": "nfldivstandings/nfldivstandings.webp",
+    "md": "nfldivstandings/README.md",
+    "description": "NFL Division Standings Follow your favorite NFL division throughout the year with this app featuring...",
+    "starFiles": [
+      "nfldivstandings.star"
+    ]
+  },
+  {
+    "name": "nflscores",
+    "image": "nflscores/screenshot.png",
+    "md": "nflscores/README.md",
+    "description": "NFL Scores for Tidbyt Displays live NFL scores and gambling odds for upcoming games. Updated every 2...",
+    "starFiles": [
+      "nfl_scores.star"
+    ]
+  },
+  {
+    "name": "nflstandings",
+    "image": "nflstandings/screenshot.png",
+    "md": "nflstandings/README.md",
+    "description": "NFL Standings for Tidbyt Displays live NFL standings by division. !NFL Standings for Tidbyt",
+    "starFiles": [
+      "nfl_standings.star"
+    ]
+  },
+  {
+    "name": "nft",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nft.star"
+    ]
+  },
+  {
+    "name": "nhdesdata",
+    "image": "nhdesdata/nhdesdata.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nh_des_data.star"
+    ]
+  },
+  {
+    "name": "nhllive",
+    "image": "nhllive/screenshot.png",
+    "md": "nhllive/README.md",
+    "description": "NHL Live Applet for Tidbyt Displays live game stats or next scheduled NHL game information. !NHL Liv...",
+    "starFiles": [
+      "nhl_live.star"
+    ]
+  },
+  {
+    "name": "nhlnextgame",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nhl_next_game.star"
+    ]
+  },
+  {
+    "name": "nhlscores",
+    "image": "nhlscores/screenshot.png",
+    "md": "nhlscores/README.md",
+    "description": "NHL Scores for Tidbyt Displays live NHL scores and gambling odds for upcoming games. Updated every 2...",
+    "starFiles": [
+      "nhl_scores.star"
+    ]
+  },
+  {
+    "name": "nhlstandings",
+    "image": "nhlstandings/screenshot.png",
+    "md": "nhlstandings/README.md",
+    "description": "NHL Standings for Tidbyt Displays live NHL standings by division. !NHL Standings for Tidbyt",
+    "starFiles": [
+      "nhl_standings.star"
+    ]
+  },
+  {
+    "name": "nightscout",
+    "image": "nightscout/screenshot.png",
+    "md": "nightscout/README.md",
+    "description": "Nightscout Blood Glucose Data Monitor for TidByt Displays Continuous Glucose Monitoring (CGM) blood ...",
+    "starFiles": [
+      "nightscout.star"
+    ]
+  },
+  {
+    "name": "nixelclock",
+    "image": "nixelclock/nixelclock.webp",
+    "md": "nixelclock/README.md",
+    "description": "Nixel Clock for Tidbyt It's a Nixie Tube Clock recreated in Pixels! Available in round or tall style...",
+    "starFiles": [
+      "nixel_clock.star"
+    ]
+  },
+  {
+    "name": "njtransit",
+    "image": null,
+    "md": "njtransit/README.md",
+    "description": "NJ Transit Depature Vision viewer\r \r Displays the trains and their departing times for a given NJ Tr...",
+    "starFiles": [
+      "nj_transit.star"
+    ]
+  },
+  {
+    "name": "noaabuoy",
+    "image": "noaabuoy/noaabuoy.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "noaa_buoy.star"
+    ]
+  },
+  {
+    "name": "noaatides",
+    "image": "noaatides/screenshot.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "noaa_tides.star"
+    ]
+  },
+  {
+    "name": "nobsbitcoin",
+    "image": "nobsbitcoin/nobsbitcoin.webp",
+    "md": "nobsbitcoin/README.md",
+    "description": "NoBsBitcoin Applet for Tidbyt Shows the the latest news article, guides, research or releases from N...",
+    "starFiles": [
+      "nobsbitcoin.star"
+    ]
+  },
+  {
+    "name": "noderunners",
+    "image": "noderunners/noderunners.webp",
+    "md": "noderunners/README.md",
+    "description": "Noderunners Applet for Tidbyt Shows the current song what is playing on Noderunners Radio. Stream: h...",
+    "starFiles": [
+      "noderunners.star"
+    ]
+  },
+  {
+    "name": "nola-streetcar",
+    "image": "nola-streetcar/nola_streetcar.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nola_streetcar.star"
+    ]
+  },
+  {
+    "name": "nolayingup",
+    "image": "nolayingup/nolayingup.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "no_laying_up.star"
+    ]
+  },
+  {
+    "name": "northernlights",
+    "image": "northernlights/northernlights.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "northern_lights.star"
+    ]
+  },
+  {
+    "name": "nos",
+    "image": "nos/nos.webp",
+    "md": "nos/README.md",
+    "description": "NOS Applet for Tidbyt Shows random one of the latest news items from the Dutch website nos.nl. Data ...",
+    "starFiles": [
+      "nos.star"
+    ]
+  },
+  {
+    "name": "nouns",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nouns.star"
+    ]
+  },
+  {
+    "name": "nova",
+    "image": "nova/nova.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nova.star"
+    ]
+  },
+  {
+    "name": "nowshowing",
+    "image": "nowshowing/nowshowing.webp",
+    "md": "nowshowing/readme.md",
+    "description": "Now Showing for Tidbyt Now Showing is an app that will display new movies showing in theaters. It wi...",
+    "starFiles": [
+      "nowshowing.star"
+    ]
+  },
+  {
+    "name": "nowspinning",
+    "image": "nowspinning/nowspinning.webp",
+    "md": "nowspinning/README.md",
+    "description": "Now Spinning Overview This app was developed by request for the user Diesel7688 on the Tidbyt Forums...",
+    "starFiles": [
+      "now_spinning.star"
+    ]
+  },
+  {
+    "name": "npmpackages",
+    "image": "npmpackages/npmpackages.webp",
+    "md": "npmpackages/README.md",
+    "description": "NPM Packages Overview This app shows the number of downloads for a NPM package for the last day, wee...",
+    "starFiles": [
+      "npm_packages.star"
+    ]
+  },
+  {
+    "name": "npr",
+    "image": "npr/npr_news.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "npr_news.star"
+    ]
+  },
+  {
+    "name": "nrlladder",
+    "image": "nrlladder/nrlladder.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nrl_ladder.star"
+    ]
+  },
+  {
+    "name": "nrlscores",
+    "image": "nrlscores/nrlscores.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nrl_scores.star"
+    ]
+  },
+  {
+    "name": "nsbyt",
+    "image": "nsbyt/nsbyt.gif",
+    "md": "nsbyt/readme.md",
+    "description": "NS Timetable app, by Tim Hanssen Allows the user to search for a NS Train station and displays the n...",
+    "starFiles": [
+      "nsbyt.star"
+    ]
+  },
+  {
+    "name": "nswfuelcheck",
+    "image": "nswfuelcheck/nswfuelcheck.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nsw_fuel_check.star"
+    ]
+  },
+  {
+    "name": "ntsradio",
+    "image": "ntsradio/ntsradio.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nts_radio.star"
+    ]
+  },
+  {
+    "name": "nunl",
+    "image": "nunl/nunl.webp",
+    "md": "nunl/README.md",
+    "description": "Nu.nl Applet for Tidbyt Shows random one of the latest news items from the Dutch website nu.nl. Data...",
+    "starFiles": [
+      "nunl.star"
+    ]
+  },
+  {
+    "name": "nws_live_forecast",
+    "image": "nws_live_forecast/nws_live_forecast.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nws_live_forecast.star"
+    ]
+  },
+  {
+    "name": "nyancat",
+    "image": "nyancat/nyancat.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nyan_cat.star"
+    ]
+  },
+  {
+    "name": "nycairquality",
+    "image": "nycairquality/nycairquality.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nyc_air_quality.star"
+    ]
+  },
+  {
+    "name": "nycaspstatus",
+    "image": "nycaspstatus/nyc_asp_status.webp",
+    "md": "nycaspstatus/README.md",
+    "description": "NYC ASP Status This app displays the current status of New York City alternate side parking (street ...",
+    "starFiles": [
+      "nyc_asp_status.star"
+    ]
+  },
+  {
+    "name": "nycbus",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "nyc_bus.star"
+    ]
+  },
+  {
+    "name": "obliquestrategies",
+    "image": "obliquestrategies/obliquestrategies.webp",
+    "md": "obliquestrategies/README.md",
+    "description": "Oblique Strategies This app cycles through 133 Oblique Strategies, novel advice for musical problems...",
+    "starFiles": [
+      "obliquestrategies.star"
+    ]
+  },
+  {
+    "name": "octoprint",
+    "image": "octoprint/octoprint.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "octoprint.star"
+    ]
+  },
+  {
+    "name": "octopus_agile",
+    "image": "octopus_agile/octopus_agile.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "octopus_agile.star"
+    ]
+  },
+  {
+    "name": "officestatus",
+    "image": "officestatus/screenshot.png",
+    "md": "officestatus/README.md",
+    "description": "office-status Display your availability to coworkers. Connect calendar and messaging apps to your Ti...",
+    "starFiles": [
+      "office_status.star"
+    ]
+  },
+  {
+    "name": "ogsgamesviewer",
+    "image": "ogsgamesviewer/ogsgamesviewer.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "ogs_games_viewer.star"
+    ]
+  },
+  {
+    "name": "ohhighwaysigns",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "oh_highway_signs.star"
+    ]
+  },
+  {
+    "name": "olympic_medals",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "olympic_medals.star"
+    ]
+  },
+  {
+    "name": "olympicmedals",
+    "image": "olympicmedals/olympicmedals.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "olympicmedals.star"
+    ]
+  },
+  {
+    "name": "onair",
+    "image": "onair/on_air.webp",
+    "md": "onair/readme.md",
+    "description": "On Air for Tidbyt Displays an old time radio station \"On Air\" sign.  Turning the \"On Air\" sign on or...",
+    "starFiles": [
+      "on_air.star"
+    ]
+  },
+  {
+    "name": "onepiecebdays",
+    "image": "onepiecebdays/onepiecebdays.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "one_piece_bdays.star"
+    ]
+  },
+  {
+    "name": "onthisday",
+    "image": "onthisday/onthisday.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "onthisday.star"
+    ]
+  },
+  {
+    "name": "opmstatus",
+    "image": "opmstatus/opmstatus.webp",
+    "md": "opmstatus/README.md",
+    "description": "OPM Status for Tidbyt Displays the current OPM Status, e.g. the Office of Personnel Management statu...",
+    "starFiles": [
+      "opm_status.star"
+    ]
+  },
+  {
+    "name": "opnvaustria",
+    "image": "opnvaustria/opnvaustria.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "opnv_austria.star"
+    ]
+  },
+  {
+    "name": "ordermoments",
+    "image": "ordermoments/ordermoments.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "order_moments.star"
+    ]
+  },
+  {
+    "name": "ordertrends",
+    "image": "ordertrends/ordertrends.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "order_trends.star"
+    ]
+  },
+  {
+    "name": "oscarscustard",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "oscars_custard.star"
+    ]
+  },
+  {
+    "name": "ouraring",
+    "image": "ouraring/ouraring.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "ouraring.star"
+    ]
+  },
+  {
+    "name": "outlookcalendar",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "outlook_calendar.star"
+    ]
+  },
+  {
+    "name": "overwatch_meta",
+    "image": "overwatch_meta/overwatch_meta.webp",
+    "md": "overwatch_meta/README.md",
+    "description": "OverwatchMetaByt A Tidbyt application that visualizes Overwatch 2 Meta statistics. App Configuration...",
+    "starFiles": [
+      "overwatch_meta.star"
+    ]
+  },
+  {
+    "name": "packagetracker",
+    "image": "packagetracker/packagetracker.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "package_tracker.star"
+    ]
+  },
+  {
+    "name": "pagerduty",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "pagerduty.star"
+    ]
+  },
+  {
+    "name": "paraland",
+    "image": "paraland/screenshot.png",
+    "md": "paraland/README.md",
+    "description": "Paraland Paraland shows you an endless parallax of perfectly looping, hand-drawn landscapes. Configu...",
+    "starFiles": [
+      "paraland.star"
+    ]
+  },
+  {
+    "name": "parktime",
+    "image": "parktime/parktime.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "park_time.star"
+    ]
+  },
+  {
+    "name": "parkwaittimes",
+    "image": "parkwaittimes/parkwaittimes.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "parkwaittimes.star"
+    ]
+  },
+  {
+    "name": "partnermetrics",
+    "image": "partnermetrics/partnermetrics.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "partnermetrics.star"
+    ]
+  },
+  {
+    "name": "partyparrot",
+    "image": "partyparrot/parrot.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "parrot.star"
+    ]
+  },
+  {
+    "name": "pathtimes",
+    "image": "pathtimes/path_times.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "path_times.star"
+    ]
+  },
+  {
+    "name": "pathtrainschedule",
+    "image": "pathtrainschedule/pathtrainschedule.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "path_train_schedule.star"
+    ]
+  },
+  {
+    "name": "pattersontimes",
+    "image": "pattersontimes/pattersontimes.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "patterson_times.star"
+    ]
+  },
+  {
+    "name": "pbjellytime",
+    "image": "pbjellytime/pbjellytime.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "pb_jelly_time.star"
+    ]
+  },
+  {
+    "name": "pdp11",
+    "image": "pdp11/pdp11.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "pdp11.star"
+    ]
+  },
+  {
+    "name": "peanutspictures",
+    "image": "peanutspictures/screenshot.png",
+    "md": "peanutspictures/README.md",
+    "description": "Peanuts Pictures Shows random pixel art of characters from the peanuts comics. Configuration You can...",
+    "starFiles": [
+      "peanuts_pictures.star"
+    ]
+  },
+  {
+    "name": "permtimeline",
+    "image": "permtimeline/permtimeline.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "perm_timeline.star"
+    ]
+  },
+  {
+    "name": "petitionsplease",
+    "image": "petitionsplease/petitionsplease.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "petitions_please.star"
+    ]
+  },
+  {
+    "name": "petpikachu",
+    "image": "petpikachu/petpikachu.png",
+    "md": "petpikachu/README.md",
+    "description": "Pet Pikachu Applet for Tidbyt Based off the Tamagotchi-like Pokémon Pikachu virtual pet from the '90...",
+    "starFiles": [
+      "petpikachu.star"
+    ]
+  },
+  {
+    "name": "pgatour",
+    "image": "pgatour/pga_tour_final.gif",
+    "md": "pgatour/README.md",
+    "description": "This app displays the leaderboard for the current PGA Tour event, taken from ESPN data feed updated ...",
+    "starFiles": [
+      "pga_tour.star"
+    ]
+  },
+  {
+    "name": "phaseofmoon",
+    "image": "phaseofmoon/phaseofmoon.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "phase_of_moon.star"
+    ]
+  },
+  {
+    "name": "pihole",
+    "image": "pihole/pihole.webp",
+    "md": "pihole/README.md",
+    "description": "PiHole PiHole displays ad blocking stats from your instance. PiHole instance should be reachable fro...",
+    "starFiles": [
+      "pihole.star"
+    ]
+  },
+  {
+    "name": "pinballmap",
+    "image": "pinballmap/pinballmap.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "pinball_map.star"
+    ]
+  },
+  {
+    "name": "pittsburghbuses",
+    "image": null,
+    "md": "pittsburghbuses/README.md",
+    "description": "Pittsburgh Regional Transit Bus Times This app displays the estimated times for buses at a given sto...",
+    "starFiles": [
+      "pittsburgh_buses.star"
+    ]
+  },
+  {
+    "name": "pixelartclock",
+    "image": "pixelartclock/pixel_art_clock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "pixel_art_clock.star"
+    ]
+  },
+  {
+    "name": "pixelgreet",
+    "image": "pixelgreet/pixelgreet.webp",
+    "md": "pixelgreet/README.md",
+    "description": "PixelGreet !render PixelGreet is a Tidbyt application designed for vacation rental hosts, enabling t...",
+    "starFiles": [
+      "pixelgreet.star"
+    ]
+  },
+  {
+    "name": "planesoverhead",
+    "image": "planesoverhead/planes_overhead.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "planes_overhead.star"
+    ]
+  },
+  {
+    "name": "planetarium",
+    "image": "planetarium/planetarium.gif",
+    "md": null,
+    "description": null,
+    "starFiles": []
+  },
+  {
+    "name": "plausibleanalytics",
+    "image": "plausibleanalytics/screenshot.png",
+    "md": "plausibleanalytics/README.md",
+    "description": "Plausible Analytics On Your Tidbyt An app for the Tidbyt that uses the plausible.io stats API to dis...",
+    "starFiles": [
+      "plausibleanalytics.star"
+    ]
+  },
+  {
+    "name": "playdatesales",
+    "image": "playdatesales/playdatesales.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "playdate_sales.star"
+    ]
+  },
+  {
+    "name": "playingoncapital",
+    "image": "playingoncapital/playingoncapital.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "playingoncapital.star"
+    ]
+  },
+  {
+    "name": "pleasestandby",
+    "image": "pleasestandby/screenshot.png",
+    "md": "pleasestandby/README.md",
+    "description": "Please Stand By for Tidbyt Displays scrolling Please Stand By message. Tried to mimic this photo:max...",
+    "starFiles": [
+      "please_stand_by.star"
+    ]
+  },
+  {
+    "name": "plexrecentlyadded",
+    "image": "plexrecentlyadded/plexrecentlyadded.webp",
+    "md": "plexrecentlyadded/README.md",
+    "description": "Plex Recently Added Shows recently added on plex server. Strongly recommend to run index.js as a pro...",
+    "starFiles": [
+      "plex_recently_added.star"
+    ]
+  },
+  {
+    "name": "plexshowtime",
+    "image": "plexshowtime/plex_showtime.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "plex_showtime.star"
+    ]
+  },
+  {
+    "name": "pokedex",
+    "image": "pokedex/pokedex.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "pokedex.star"
+    ]
+  },
+  {
+    "name": "pokedexplus",
+    "image": "pokedexplus/pokedexplus.webp",
+    "md": "pokedexplus/readme.md",
+    "description": "Pokédex+ Displays a random Pokémon from all generations. A Pokédex for your desk! !pokedex+ > (note:...",
+    "starFiles": [
+      "pokedexplus.star"
+    ]
+  },
+  {
+    "name": "poktstats",
+    "image": "poktstats/screenshot.png",
+    "md": "poktstats/README.md",
+    "description": "POKT Stats applet for Tidbyt Displays the current USD/POKT token price sourced from coinstats, as we...",
+    "starFiles": [
+      "poktstats.star"
+    ]
+  },
+  {
+    "name": "pollencount",
+    "image": "pollencount/pollencount-preview.png",
+    "md": "pollencount/README.md",
+    "description": "Pollen Count Shows the current allergen count for your general area. Lists the current count 1-5 and...",
+    "starFiles": [
+      "pollen_count.star"
+    ]
+  },
+  {
+    "name": "pomodoro",
+    "image": "pomodoro/pomodoro.webp",
+    "md": "pomodoro/README.md",
+    "description": "Pomodoro A pomodoro timer for Tidbyt! Displayed: The current step of the pomodori A progress bar for...",
+    "starFiles": [
+      "pomodoro.star"
+    ]
+  },
+  {
+    "name": "positivequote",
+    "image": "positivequote/positivequote.webp",
+    "md": "positivequote/README.md",
+    "description": "Positive Quote Applet for Tidbyt Displays the a positive quote from https://www.affirmations.dev. Th...",
+    "starFiles": [
+      "positive_quote.star"
+    ]
+  },
+  {
+    "name": "powerball",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "powerball.star"
+    ]
+  },
+  {
+    "name": "powerwall",
+    "image": "powerwall/powerwall.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "powerwall.star"
+    ]
+  },
+  {
+    "name": "prayer_times",
+    "image": "prayer_times/prayer_times.png",
+    "md": "prayer_times/README.md",
+    "description": "Islamic Prayer Times This app displays the prayer times for today's date based on the user location ...",
+    "starFiles": [
+      "prayer_times.star"
+    ]
+  },
+  {
+    "name": "preciousmetals",
+    "image": "preciousmetals/precious_metals.gif",
+    "md": "preciousmetals/README.md",
+    "description": "Precious Metals for Tidbyt Displays the current prices on Silver, Gold and Platinum from api.metals....",
+    "starFiles": [
+      "precious_metals.star"
+    ]
+  },
+  {
+    "name": "pregnancytracker",
+    "image": "pregnancytracker/pregnancytracker.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "pregnancy_tracker.star"
+    ]
+  },
+  {
+    "name": "priceisright",
+    "image": "priceisright/priceisright.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "price_is_right.star"
+    ]
+  },
+  {
+    "name": "producthunt",
+    "image": null,
+    "md": "producthunt/README.md",
+    "description": "Product Hunt Overview This app shows the daily top tech products being launched on Product Hunt. The...",
+    "starFiles": [
+      "product_hunt.star"
+    ]
+  },
+  {
+    "name": "progressclock",
+    "image": "progressclock/progressclock.webp",
+    "md": "progressclock/README.md",
+    "description": "Progress Clock Author: Jeffery Bennett See the time displayed & how much of the day has passed, as r...",
+    "starFiles": [
+      "progressclock.star"
+    ]
+  },
+  {
+    "name": "pslcricket",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "psl_cricket.star"
+    ]
+  },
+  {
+    "name": "pubgstats",
+    "image": "pubgstats/pubg_stats.gif",
+    "md": "pubgstats/README.md",
+    "description": "PUBG Stats PUBG Stats displays a selected lifetime statistic for any given PUBG player on Steam, PSN...",
+    "starFiles": [
+      "pubg_stats.star"
+    ]
+  },
+  {
+    "name": "publicapi",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "publicapi.star"
+    ]
+  },
+  {
+    "name": "pull_request_status",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "pull_request_status.star"
+    ]
+  },
+  {
+    "name": "pulsechain",
+    "image": "pulsechain/pulsechain.png",
+    "md": "pulsechain/README.md",
+    "description": "PulseChain for Tidbyt Made by: bretep   Twitter: @bretep   Telegram: bretep   Displays the price of ...",
+    "starFiles": [
+      "pulsechain.star"
+    ]
+  },
+  {
+    "name": "pulseprice",
+    "image": "pulseprice/pulseprice.png",
+    "md": "pulseprice/README.md",
+    "description": "Pulse Price Applet for Tidbyt Displays the USD prices for PLS, PLSX and INC tokens on PulseChain on ...",
+    "starFiles": [
+      "pulseprice.star"
+    ]
+  },
+  {
+    "name": "pulsetracker",
+    "image": "pulsetracker/pulsetracker.webp",
+    "md": "pulsetracker/README.md",
+    "description": "Pulse Tracker Applet for Tidbyt Displays PulseChain token prices and price changes in USD over the l...",
+    "starFiles": [
+      "pulsetracker.star"
+    ]
+  },
+  {
+    "name": "purduebasketball",
+    "image": "purduebasketball/purduebasketball.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "purdue_basketball.star"
+    ]
+  },
+  {
+    "name": "purpleair",
+    "image": "purpleair/screenshot.png",
+    "md": "purpleair/readme.md",
+    "description": "PurpleAir for Tidbyt PurpleAir displays an estimate of the air quality index (AQI) using the specifi...",
+    "starFiles": [
+      "purpleair.star"
+    ]
+  },
+  {
+    "name": "qbittorrent",
+    "image": "qbittorrent/qbittorrent.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "qbittorrent.star"
+    ]
+  },
+  {
+    "name": "qlock",
+    "image": "qlock/screenshot.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "qlock.star"
+    ]
+  },
+  {
+    "name": "quoteoftheday",
+    "image": "quoteoftheday/quote_of_the_day.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "quote_of_the_day.star"
+    ]
+  },
+  {
+    "name": "raafuelwatch",
+    "image": "raafuelwatch/raa_fuel_watch.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "raa_fuel_watch.star"
+    ]
+  },
+  {
+    "name": "rachio",
+    "image": "rachio/rachio.webp",
+    "md": "rachio/readme.md",
+    "description": "Rachio Applet for Tidbyt Displays your Rachio events.  Pick your device and your preferences and it ...",
+    "starFiles": [
+      "rachio.star"
+    ]
+  },
+  {
+    "name": "randomcats",
+    "image": "randomcats/randomcats.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "random_cats.star"
+    ]
+  },
+  {
+    "name": "randomcolors",
+    "image": "randomcolors/randomcolors.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "random_colors.star"
+    ]
+  },
+  {
+    "name": "randomdogs",
+    "image": "randomdogs/randomdogs.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "random_dogs.star"
+    ]
+  },
+  {
+    "name": "randomnumbers",
+    "image": "randomnumbers/randomnumbers.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "random_numbers.star"
+    ]
+  },
+  {
+    "name": "randompokedex",
+    "image": "randompokedex/random_pokedex.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "random_pokedex.star"
+    ]
+  },
+  {
+    "name": "randomrecipe",
+    "image": "randomrecipe/randomrecipe.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "random_recipe.star"
+    ]
+  },
+  {
+    "name": "randomslackmoji",
+    "image": "randomslackmoji/randomslackmoji.webp",
+    "md": "randomslackmoji/README.md",
+    "description": "Random Slackmoji for Tidbyt Made by: btjones Displays a random image from slackmojis.com on your Tid...",
+    "starFiles": [
+      "random_slackmoji.star"
+    ]
+  },
+  {
+    "name": "rantinglynews",
+    "image": "rantinglynews/rantinglynews.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "rantinglynews.star"
+    ]
+  },
+  {
+    "name": "rawmetar",
+    "image": "rawmetar/rawmetar.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "raw_metar.star"
+    ]
+  },
+  {
+    "name": "readingchallenge",
+    "image": "readingchallenge/reading_challenge.png",
+    "md": "readingchallenge/README.md",
+    "description": "Goodreads yearly reading challenge progress  Displays the progress of your reading challenge along w...",
+    "starFiles": [
+      "reading_challenge.star"
+    ]
+  },
+  {
+    "name": "redditimages",
+    "image": null,
+    "md": "redditimages/README.md",
+    "description": "Reddit Image Shuffler For Tidbyt Displays a random image post from subreddits you specify and/or a l...",
+    "starFiles": [
+      "reddit_images.star"
+    ]
+  },
+  {
+    "name": "redditrplace",
+    "image": null,
+    "md": "redditrplace/README.md",
+    "description": "r/place 2022 Tidbyt Viewer Displays random bits of the final (and cleaned) r/place 2022 & 2017 commu...",
+    "starFiles": [
+      "reddit_r_place.star"
+    ]
+  },
+  {
+    "name": "relay_fm_live",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "relay_fm_live.star"
+    ]
+  },
+  {
+    "name": "restdbiodashboard",
+    "image": "restdbiodashboard/restdbiodashboard.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "restdbiodashboard.star"
+    ]
+  },
+  {
+    "name": "retrogamegoals",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "retro_game_goals.star"
+    ]
+  },
+  {
+    "name": "retrogradeplanet",
+    "image": "retrogradeplanet/retrograde_planet.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "retrograde_planet.star"
+    ]
+  },
+  {
+    "name": "roblox",
+    "image": null,
+    "md": "roblox/README.md",
+    "description": "Roblox for Tidbyt Displays an online friends or favorite games view for a specified Roblox username....",
+    "starFiles": [
+      "roblox.star"
+    ]
+  },
+  {
+    "name": "rocketleaguestats",
+    "image": "rocketleaguestats/rocketleaguestats.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "rocketleaguestats.star"
+    ]
+  },
+  {
+    "name": "roomba",
+    "image": "roomba/roomba.webp",
+    "md": "roomba/README.md",
+    "description": "Roomba\r \r Show status of Roomba. Requires a server (raspbi on local network preferrably) running ind...",
+    "starFiles": [
+      "roomba.star"
+    ]
+  },
+  {
+    "name": "rssmiscfeeds",
+    "image": "rssmiscfeeds/rssmiscfeeds.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "rss_misc_feeds.star"
+    ]
+  },
+  {
+    "name": "rssreader",
+    "image": "rssreader/rssreader.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "rss_reader.star"
+    ]
+  },
+  {
+    "name": "rules4life",
+    "image": "rules4life/rules4life.webp",
+    "md": "rules4life/readme.md",
+    "description": "Rules 4 Life Applet for Tidbyt Displays one of the 12 Rules for Life from the book by Jordan B. Pete...",
+    "starFiles": [
+      "rules4life.star"
+    ]
+  },
+  {
+    "name": "runescape",
+    "image": "runescape/runescape.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "runescape.star"
+    ]
+  },
+  {
+    "name": "sa20cricket",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sa20_cricket.star"
+    ]
+  },
+  {
+    "name": "sailgp",
+    "image": "sailgp/sailgp.webp",
+    "md": "sailgp/README.md",
+    "description": "SailGP Next Race and Standings SailGP displays next race details and current standings details. Disp...",
+    "starFiles": [
+      "sailgp.star"
+    ]
+  },
+  {
+    "name": "salestrends",
+    "image": "salestrends/salestrends.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sales_trends.star"
+    ]
+  },
+  {
+    "name": "sandiegotrolley",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "san_diego_trolley.star"
+    ]
+  },
+  {
+    "name": "sanflladder",
+    "image": "sanflladder/sanfl_ladder.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sanfl_ladder.star"
+    ]
+  },
+  {
+    "name": "sanflscores",
+    "image": "sanflscores/sanfl_scores.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sanfl_scores.star"
+    ]
+  },
+  {
+    "name": "satoshiradio",
+    "image": "satoshiradio/satoshiradio.png",
+    "md": "satoshiradio/README.md",
+    "description": "Satoshi Radio This app shows stats from the Satoshi Radio mining pool. Displayed: Actual pool hashra...",
+    "starFiles": [
+      "satoshiradio.star"
+    ]
+  },
+  {
+    "name": "sbbtimetable",
+    "image": "sbbtimetable/sbbtimetable.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sbb_timetable.star"
+    ]
+  },
+  {
+    "name": "schopenhauer",
+    "image": "schopenhauer/schopenhauer.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "schopenhauer.star"
+    ]
+  },
+  {
+    "name": "seattletransit",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "seattle_transit.star"
+    ]
+  },
+  {
+    "name": "seinfeldquotes",
+    "image": "seinfeldquotes/seinfeldquotes.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "seinfeldquotes.star"
+    ]
+  },
+  {
+    "name": "septaregionalrail",
+    "image": "septaregionalrail/septaregionalrail.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "septaregionalrail.star"
+    ]
+  },
+  {
+    "name": "septatransit",
+    "image": "septatransit/septatransit.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "septatransit.star"
+    ]
+  },
+  {
+    "name": "setforlife",
+    "image": "setforlife/set_for_life.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "set_for_life.star"
+    ]
+  },
+  {
+    "name": "severewxalertsusa",
+    "image": "severewxalertsusa/severewxalertsusa.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "severewxalertsusa.star"
+    ]
+  },
+  {
+    "name": "sfbayferry",
+    "image": "sfbayferry/sfbf.webp",
+    "md": "sfbayferry/readme.md",
+    "description": "San Francisco Bay Ferry Applet for Tidbyt Displays next ferry departure times for [San Francisco Bay...",
+    "starFiles": [
+      "sfbf.star"
+    ]
+  },
+  {
+    "name": "sffogtoday",
+    "image": "sffogtoday/sffogtoday.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sf_fog_today.star"
+    ]
+  },
+  {
+    "name": "sfnextmuni",
+    "image": "sfnextmuni/default.gif",
+    "md": "sfnextmuni/readme.md",
+    "description": "San Francisco NextBus Applet for Tidbyt Displays predicted arrival times from the NextBus API for Sa...",
+    "starFiles": [
+      "sf_next_muni.star"
+    ]
+  },
+  {
+    "name": "shabbat",
+    "image": "shabbat/shabbat.png",
+    "md": "shabbat/README.md",
+    "description": "Weekly Shabbat Times for Tidbyt Displays weekly shabbat times on your Tidbyt.  User can select metho...",
+    "starFiles": [
+      "shabbat.star"
+    ]
+  },
+  {
+    "name": "shippingforecast",
+    "image": "shippingforecast/shippingforecast.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "shippingforecast.star"
+    ]
+  },
+  {
+    "name": "shipweatherclock",
+    "image": "shipweatherclock/shipweatherclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "shipweatherclock.star"
+    ]
+  },
+  {
+    "name": "shopifyanimation",
+    "image": "shopifyanimation/shopifyanimation.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "shopify_animation.star"
+    ]
+  },
+  {
+    "name": "shopifychart",
+    "image": "shopifychart/shopify.png",
+    "md": "shopifychart/README.md",
+    "description": "Shopify Daily Metrics Displays daily metrics for your Shopify store. Note that you must generate a S...",
+    "starFiles": [
+      "shopify_chart.star"
+    ]
+  },
+  {
+    "name": "shopifymemories",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "shopify_memories.star"
+    ]
+  },
+  {
+    "name": "shopifyneworder",
+    "image": "shopifyneworder/shopifyneworder.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "shopify_new_order.star"
+    ]
+  },
+  {
+    "name": "shopifyorders",
+    "image": "shopifyorders/shopifyorders.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "shopify_orders.star"
+    ]
+  },
+  {
+    "name": "shopifysales",
+    "image": "shopifysales/shopifysales.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "shopify_sales.star"
+    ]
+  },
+  {
+    "name": "shouldideploy",
+    "image": "shouldideploy/should_i_deploy.gif",
+    "md": "shouldideploy/README.md",
+    "description": "Should I Deploy Applet for Tidbyt Displays the response from ShouldIDeploy on your Tidbyt. !Should I...",
+    "starFiles": [
+      "should_i_deploy.star"
+    ]
+  },
+  {
+    "name": "shouldideploytoday",
+    "image": "shouldideploytoday/shouldideploytoday.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "shouldideploy.star"
+    ]
+  },
+  {
+    "name": "showtime",
+    "image": "showtime/showtime.webp",
+    "md": "showtime/readme.md",
+    "description": "ShowTime Applet for Tidbyt ShowTime will let you pick a region, and then pick a local area in that r...",
+    "starFiles": [
+      "showtime.star"
+    ]
+  },
+  {
+    "name": "shuffleimages",
+    "image": "shuffleimages/shuffleimages.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "shuffle_images.star"
+    ]
+  },
+  {
+    "name": "siderealtimeclock",
+    "image": "siderealtimeclock/sidereal_time.webp",
+    "md": "siderealtimeclock/README.md",
+    "description": "Sidereal Time Clock Overview This app displays the current time using Sidereal Time calculations. Th...",
+    "starFiles": [
+      "sidereal_time.star"
+    ]
+  },
+  {
+    "name": "simplescoreboard",
+    "image": "simplescoreboard/simplescoreboard.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "simple_scoreboard.star"
+    ]
+  },
+  {
+    "name": "skicolorado",
+    "image": null,
+    "md": "skicolorado/README.md",
+    "description": "Colorado Ski Report for Tidbyt Displays the: Weather Base/Summit Snow Depth Lift/Trail Status For al...",
+    "starFiles": [
+      "skicolorado.star"
+    ]
+  },
+  {
+    "name": "skireport",
+    "image": "skireport/ski_report.gif",
+    "md": "skireport/README.md",
+    "description": "Ski Report for Tidbyt\r \r Displays the trail status, temperature and snowfall in the last 24 hours fo...",
+    "starFiles": [
+      "ski_report.star"
+    ]
+  },
+  {
+    "name": "skordlebbfem",
+    "image": "skordlebbfem/skordlebbfem.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "skordle_bb_fem.star"
+    ]
+  },
+  {
+    "name": "skordlebbmale",
+    "image": "skordlebbmale/skordlebbmale.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "skordle_bb_male.star"
+    ]
+  },
+  {
+    "name": "skordlefastpitch",
+    "image": "skordlefastpitch/skordlefastpitch.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "skordlefastpitch.star"
+    ]
+  },
+  {
+    "name": "skordlefbaseball",
+    "image": "skordlefbaseball/skordlefbaseball.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "skordlefbaseball.star"
+    ]
+  },
+  {
+    "name": "skordlesbaseball",
+    "image": "skordlesbaseball/skordlesbaseball.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "skordlesbaseball.star"
+    ]
+  },
+  {
+    "name": "skordlescores",
+    "image": "skordlescores/skordlescores.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "skordle_scores.star"
+    ]
+  },
+  {
+    "name": "skordleslowpitch",
+    "image": "skordleslowpitch/skordleslowpitch.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "skordleslowpitch.star"
+    ]
+  },
+  {
+    "name": "skordlesoftball",
+    "image": "skordlesoftball/skordlesoftball.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "skordlesoftball.star"
+    ]
+  },
+  {
+    "name": "skordlevolleyball",
+    "image": "skordlevolleyball/skordlevolleyball.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "skordlevolleyball.star"
+    ]
+  },
+  {
+    "name": "skybyt",
+    "image": "skybyt/skybyt.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "skybyt.star"
+    ]
+  },
+  {
+    "name": "skynews",
+    "image": "skynews/skynews.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "skynews.star"
+    ]
+  },
+  {
+    "name": "skynewsrss",
+    "image": "skynewsrss/sky_news_rss.gif",
+    "md": "skynewsrss/README.md",
+    "description": "Sky News Headlines Sky news headlines displays current headline articles (up to 3) for the selected ...",
+    "starFiles": [
+      "sky_news_rss.star"
+    ]
+  },
+  {
+    "name": "sleeperfantasyfootball",
+    "image": "sleeperfantasyfootball/sleeperfantasynfl.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sleeperfantasynfl.star"
+    ]
+  },
+  {
+    "name": "slippirank",
+    "image": "slippirank/slippirank.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "slippirank.star"
+    ]
+  },
+  {
+    "name": "slippistats",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "slippistats.star"
+    ]
+  },
+  {
+    "name": "sliverpizza",
+    "image": "sliverpizza/sliverpizza.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sliver_pizza.star"
+    ]
+  },
+  {
+    "name": "slotMachineClock",
+    "image": "slotMachineClock/slotMachineClock.webp",
+    "md": "slotMachineClock/README.md",
+    "description": "slotMachineClock Tidbyt app to display the time via slot machine, takes in a user input on the speed...",
+    "starFiles": [
+      "slotMachineClock.star"
+    ]
+  },
+  {
+    "name": "smoothfm",
+    "image": "smoothfm/smoothfm.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "smooth_fm.star"
+    ]
+  },
+  {
+    "name": "snake",
+    "image": "snake/snake.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "snake.star"
+    ]
+  },
+  {
+    "name": "snake2",
+    "image": "snake2/snake2.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "snake2.star"
+    ]
+  },
+  {
+    "name": "snakeclock",
+    "image": "snakeclock/snakeclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "snake_clock.star"
+    ]
+  },
+  {
+    "name": "snyk",
+    "image": "snyk/screenshot.png",
+    "md": "snyk/README.md",
+    "description": "Snyk for Tidbyt Snyk is an open source security platform for finding out vulnerabilities in source c...",
+    "starFiles": [
+      "snyk.star"
+    ]
+  },
+  {
+    "name": "sobrietycounter",
+    "image": "sobrietycounter/sobriety_counter_with_addiction.gif",
+    "md": "sobrietycounter/README.md",
+    "description": "Sobriety Counter Celebrate your sobriety by counting how many days since your sober date! You can ch...",
+    "starFiles": [
+      "sobriety_counter.star"
+    ]
+  },
+  {
+    "name": "soccermens",
+    "image": "soccermens/soccermens.gif",
+    "md": "soccermens/README.md",
+    "description": "Men's soccer tournament / league Men's soccer displays upcoming / current / completed games for tour...",
+    "starFiles": [
+      "soccermens.star"
+    ]
+  },
+  {
+    "name": "soccersingle",
+    "image": "soccersingle/soccersingle-schema-teamsearch-2.jpg",
+    "md": "soccersingle/README.md",
+    "description": "Track single soccer team across all global tournaments / leagues they are playing in Show upcoming /...",
+    "starFiles": [
+      "soccer_single.star"
+    ]
+  },
+  {
+    "name": "soccertables",
+    "image": "soccertables/soccer_tables.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "soccer_tables.star"
+    ]
+  },
+  {
+    "name": "soccerwomens",
+    "image": "soccerwomens/soccerwomens.gif",
+    "md": "soccerwomens/README.md",
+    "description": "Women's soccer tournament / league Women's soccer displays upcoming / current / completed games for ...",
+    "starFiles": [
+      "soccerwomens.star"
+    ]
+  },
+  {
+    "name": "solaredge",
+    "image": "solaredge/screenshot.png",
+    "md": "solaredge/README.md",
+    "description": "SolarEdge Monitoring Applet for Tidbyt Displays real-time solar panel production data from your Sola...",
+    "starFiles": [
+      "solaredge.star"
+    ]
+  },
+  {
+    "name": "solaredgemonitor",
+    "image": "solaredgemonitor/screenshot.png",
+    "md": "solaredgemonitor/README.md",
+    "description": "SolarEdge Monitoring Applet for Tidbyt Displays real-time solar panel production data from your Sola...",
+    "starFiles": [
+      "solaredge_monitor.star"
+    ]
+  },
+  {
+    "name": "solaredgeoverview",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "solaredge.star"
+    ]
+  },
+  {
+    "name": "solaredgeprod",
+    "image": "solaredgeprod/solaredgeprod.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "solaredge_prod.star"
+    ]
+  },
+  {
+    "name": "solarelevation",
+    "image": "solarelevation/solarelevation.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "solar_elevation.star"
+    ]
+  },
+  {
+    "name": "solarmanagerch",
+    "image": "solarmanagerch/solarmanagerch.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "solar_manager_ch.star"
+    ]
+  },
+  {
+    "name": "solarpowerwall",
+    "image": "solarpowerwall/solar_powerwall.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "solar_powerwall.star"
+    ]
+  },
+  {
+    "name": "solartimeclock",
+    "image": "solartimeclock/solartimeclock.webp",
+    "md": "solartimeclock/README.md",
+    "description": "Solar Time Clock Overview This app displays the current time using Solar Time calculations. The impl...",
+    "starFiles": [
+      "solar_time_clock.star"
+    ]
+  },
+  {
+    "name": "solarweatherclock",
+    "image": "solarweatherclock/solarweatherclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "solarweatherclock.star"
+    ]
+  },
+  {
+    "name": "sonicthehedgehogclock",
+    "image": "sonicthehedgehogclock/sonicthehedgehogclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sonicthehedgehogclock.star"
+    ]
+  },
+  {
+    "name": "sort",
+    "image": "sort/sort.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sort.star"
+    ]
+  },
+  {
+    "name": "soundtransit",
+    "image": "soundtransit/sound_transit.gif",
+    "md": "soundtransit/README.md",
+    "description": "Sound Transit Applet for Tidbyt Displays up to 2 different stations in the Sound Transit Link Light ...",
+    "starFiles": [
+      "sound_transit.star"
+    ]
+  },
+  {
+    "name": "spacexlaunch",
+    "image": "spacexlaunch/error.png",
+    "md": "spacexlaunch/README.md",
+    "description": "SpaceX Launch by rytrose SpaceX Launch displays information about an upcoming SpaceX rocket launch. ...",
+    "starFiles": [
+      "spacex_launch.star"
+    ]
+  },
+  {
+    "name": "spanishwotd",
+    "image": "spanishwotd/spanishwotd.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "spanish_wotd.star"
+    ]
+  },
+  {
+    "name": "spectro_cloud_clock",
+    "image": "spectro_cloud_clock/spectro_cloud.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "spectro_cloud.star"
+    ]
+  },
+  {
+    "name": "spinbyt",
+    "image": "spinbyt/spinbyt-2.png",
+    "md": "spinbyt/README.md",
+    "description": "Spinbyt App for pixlet device, the Tidbyt, to display information about local Spin scooters.  Includ...",
+    "starFiles": [
+      "spinbyt.star"
+    ]
+  },
+  {
+    "name": "splat3challenges",
+    "image": "splat3challenges/splat3challenges.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "splat3_challenges.star"
+    ]
+  },
+  {
+    "name": "splatoon3schedule",
+    "image": "splatoon3schedule/splatoon3schedule.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "splatoon3schedule.star"
+    ]
+  },
+  {
+    "name": "splatoon3stages",
+    "image": "splatoon3stages/splatoon3stages.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "splatoon_3_stages.star"
+    ]
+  },
+  {
+    "name": "sportsrankings",
+    "image": "sportsrankings/sports_rankings.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sports_rankings.star"
+    ]
+  },
+  {
+    "name": "sportsscoreboard",
+    "image": "sportsscoreboard/sports_scoreboard.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sports_scoreboard.star"
+    ]
+  },
+  {
+    "name": "sportsscores",
+    "image": "sportsscores/sportsscores.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sports_scores.star"
+    ]
+  },
+  {
+    "name": "sportsstandings",
+    "image": "sportsstandings/sportsstandings.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sports_standings.star"
+    ]
+  },
+  {
+    "name": "spotifyFriends",
+    "image": "spotifyFriends/spotify_friends.webp",
+    "md": "spotifyFriends/README.md",
+    "description": "Spotify Friends Display for Tidbyt This app displays the most recently played song for a random spot...",
+    "starFiles": [
+      "spotify_friends.star"
+    ]
+  },
+  {
+    "name": "spotthestation",
+    "image": "spotthestation/SpotTheStation.jpg",
+    "md": "spotthestation/readme.md",
+    "description": "Spot the Station Applet for Tidbyt Displays the next viewing opportunity of the International Space ...",
+    "starFiles": [
+      "spotthestation.star"
+    ]
+  },
+  {
+    "name": "stackernews",
+    "image": "stackernews/stackernews.webp",
+    "md": "stackernews/README.md",
+    "description": "Stackernews Applet for Tidbyt Shows the top post (or random of last 5 posts) on Stacker.news in cate...",
+    "starFiles": [
+      "stackernews.star"
+    ]
+  },
+  {
+    "name": "stadiumtracker",
+    "image": "stadiumtracker/stadium_tracker.webp",
+    "md": "stadiumtracker/readme.md",
+    "description": "Stadium Tracker for Tidbyt Stadium Tracker This application will let you track which NFL stadiums an...",
+    "starFiles": [
+      "stadium_tracker.star"
+    ]
+  },
+  {
+    "name": "stardateclock",
+    "image": "stardateclock/stardate.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "stardate.star"
+    ]
+  },
+  {
+    "name": "starfield",
+    "image": "starfield/starfield.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "starfield.star"
+    ]
+  },
+  {
+    "name": "stateflags",
+    "image": "stateflags/state_flags.webp",
+    "md": "stateflags/readme.md",
+    "description": "State Flags for Tidbyt Display 5 states at random, or pick a specific state flag to fly all the time...",
+    "starFiles": [
+      "state_flags.star"
+    ]
+  },
+  {
+    "name": "statesvisited",
+    "image": "statesvisited/states_visited.gif",
+    "md": "statesvisited/README.md",
+    "description": "States Visited Keep track of the states you've visited and show a fun map of your progress across th...",
+    "starFiles": [
+      "states_visited.star"
+    ]
+  },
+  {
+    "name": "steam",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "steam.star"
+    ]
+  },
+  {
+    "name": "steam_plus",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "steam_plus.star"
+    ]
+  },
+  {
+    "name": "steamtopsellers",
+    "image": "steamtopsellers/steamtopsellers.webp",
+    "md": "steamtopsellers/README.md",
+    "description": "Steam Top Sellers (A Tidbyt App) Overview A simple Tidbyt appliction intended to render a random sel...",
+    "starFiles": [
+      "steam_top_sellers.star"
+    ]
+  },
+  {
+    "name": "stepcounter",
+    "image": "stepcounter/stepcounter_weekly.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "stepcounter.star"
+    ]
+  },
+  {
+    "name": "stockdata",
+    "image": "stockdata/stockdata.png",
+    "md": "stockdata/README.md",
+    "description": "Stock Ticker for Tidbyt Allows you to track the value of a stock as a chart with intraday or histori...",
+    "starFiles": [
+      "stockdata.star"
+    ]
+  },
+  {
+    "name": "stockfagi",
+    "image": null,
+    "md": "stockfagi/README.md",
+    "description": "StockFagi Applet for Tidbyt Contributed by jondkelley. Based off btcfagi by PMK (@pmk) Shows the 'Fe...",
+    "starFiles": [
+      "stockfagi.star"
+    ]
+  },
+  {
+    "name": "stockspotlight",
+    "image": "stockspotlight/stockspotlight.webp",
+    "md": "stockspotlight/README.md",
+    "description": "!Tidbyt Screenshot Stock Spotlight Stock Spotlight is a Tidbyt applet that allows you to add up to 3...",
+    "starFiles": [
+      "stock-spotlight.star"
+    ]
+  },
+  {
+    "name": "stockticker",
+    "image": "stockticker/stockticker.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "stock_ticker.star"
+    ]
+  },
+  {
+    "name": "stockvalue",
+    "image": "stockvalue/stock_value.gif",
+    "md": "stockvalue/README.md",
+    "description": "Stock Value Price Applet for Tidbyt Allows you to track the value of a stock that you currently own....",
+    "starFiles": [
+      "stock_value.star"
+    ]
+  },
+  {
+    "name": "stonks",
+    "image": "stonks/example1.png",
+    "md": "stonks/README.md",
+    "description": "Stonks Stonks is a simple stock market app that fetches end-of-day stock quotes using the Polygon.io...",
+    "starFiles": [
+      "stonks.star"
+    ]
+  },
+  {
+    "name": "stop_hitting_mets",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "stop_hitting_mets.star"
+    ]
+  },
+  {
+    "name": "strava",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "strava.star"
+    ]
+  },
+  {
+    "name": "stripesales",
+    "image": "stripesales/stripesales.webp",
+    "md": "stripesales/README.md",
+    "description": "Stripe Sales App for Tidbyt This app displays the total sum and count of the sales you've made on St...",
+    "starFiles": [
+      "stripe_sales.star"
+    ]
+  },
+  {
+    "name": "stripespotlight",
+    "image": "stripespotlight/stripespotlight.webp",
+    "md": "stripespotlight/README.md",
+    "description": "!Tidbyt Screenshot Stripe Spotlight Stripe Spotlight is a Tidbyt applet that showcases the gross vol...",
+    "starFiles": [
+      "stripe-spotlight.star"
+    ]
+  },
+  {
+    "name": "stupidchat",
+    "image": "stupidchat/stupid_chat.png",
+    "md": "stupidchat/README.md",
+    "description": "stupid.chat for Tidbyt Send messages and pictures to your Tidbyt from anywhere. Visit https://stupid...",
+    "starFiles": [
+      "stupid_chat.star"
+    ]
+  },
+  {
+    "name": "subreddit",
+    "image": "subreddit/subreddit.webp",
+    "md": "subreddit/README.md",
+    "description": "Subreddit Applet for Tidbyt Displays the #1 post of a given subreddit on your Tidbyt. Data provided ...",
+    "starFiles": [
+      "subreddit.star"
+    ]
+  },
+  {
+    "name": "summercountdown",
+    "image": "summercountdown/summercountdown.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "summer_countdown.star"
+    ]
+  },
+  {
+    "name": "sunrisesunset",
+    "image": "sunrisesunset/sunrisesunset.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sunrise_sunset.star"
+    ]
+  },
+  {
+    "name": "superbowl",
+    "image": "superbowl/superbowl.gif",
+    "md": null,
+    "description": null,
+    "starFiles": []
+  },
+  {
+    "name": "supermariokart",
+    "image": "supermariokart/supermariokart.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "super_mario_kart.star"
+    ]
+  },
+  {
+    "name": "surfforecast",
+    "image": "surfforecast/screenshot.png",
+    "md": "surfforecast/README.md",
+    "description": "Surf Forecast App for Tidbyt Displays the day's surf forecast using data provided by the Surfline AP...",
+    "starFiles": [
+      "surf_forecast.star"
+    ]
+  },
+  {
+    "name": "surflive",
+    "image": "surflive/surflive.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "surflive.star"
+    ]
+  },
+  {
+    "name": "sverigesradio",
+    "image": "sverigesradio/sverigesradio.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "sveriges_radio.star"
+    ]
+  },
+  {
+    "name": "swedishnameday",
+    "image": "swedishnameday/swedishnameday.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "swedish_name_day.star"
+    ]
+  },
+  {
+    "name": "switchboard",
+    "image": "switchboard/switchboard.webp",
+    "md": "switchboard/README.md",
+    "description": "Displays Switchboard data for your organization. Data provided by Switchboard. Updated every 2 minut...",
+    "starFiles": [
+      "switchboard.star"
+    ]
+  },
+  {
+    "name": "swo",
+    "image": "swo/swo.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "swo.star"
+    ]
+  },
+  {
+    "name": "synthsolar",
+    "image": "synthsolar/synthsolar.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "synth_solar.star"
+    ]
+  },
+  {
+    "name": "t20blast",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "t20_blast.star"
+    ]
+  },
+  {
+    "name": "tagesschau-news",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tagesschau_news.star"
+    ]
+  },
+  {
+    "name": "tankerkoenig",
+    "image": "tankerkoenig/tankerkoenig.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tankerkoenig.star"
+    ]
+  },
+  {
+    "name": "tar1090adsb",
+    "image": "tar1090adsb/tar1090adsb.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tar1090_ads_b.star"
+    ]
+  },
+  {
+    "name": "tarotcards",
+    "image": "tarotcards/tarotcards.webp",
+    "md": "tarotcards/README.md",
+    "description": "Tarot Cards for Tidbyt Displays random tarot card spreads with their images, names, and meanings. !T...",
+    "starFiles": [
+      "tarot_cards.star"
+    ]
+  },
+  {
+    "name": "tartan",
+    "image": "tartan/balmoral.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tartan.star"
+    ]
+  },
+  {
+    "name": "taxiwaysigns",
+    "image": "taxiwaysigns/taxiway_signs.webp",
+    "md": "taxiwaysigns/readme.md",
+    "description": "Taxiway Signs Applet for Tidbyt Displays a randomly generated Airport Taxiway Sign This will randoml...",
+    "starFiles": [
+      "taxiway_signs.star"
+    ]
+  },
+  {
+    "name": "tcatbusarrivals",
+    "image": "tcatbusarrivals/tcatbusarrivals.webp",
+    "md": "tcatbusarrivals/README.md",
+    "description": "TCAT Bus Arrivals This app displays all upcoming arrivals at a selcted TCAT bus stop, prioritized by...",
+    "starFiles": [
+      "tcat_bus_arrivals.star"
+    ]
+  },
+  {
+    "name": "telegram",
+    "image": "telegram/telegram.webp",
+    "md": "telegram/README.md",
+    "description": "Telegram Overview This app uses the Telegram BOT API to show the number of members of a given group/...",
+    "starFiles": [
+      "telegram.star"
+    ]
+  },
+  {
+    "name": "tempest",
+    "image": "tempest/tempest.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "resources.star",
+      "tempest.star"
+    ]
+  },
+  {
+    "name": "tempgraph",
+    "image": "tempgraph/tempgraph.gif",
+    "md": "tempgraph/README.md",
+    "description": "Temp Graph Overview This app uses the Weather API service to show the current temperature at a given...",
+    "starFiles": [
+      "tempgraph.star"
+    ]
+  },
+  {
+    "name": "tencommandments",
+    "image": "tencommandments/ten_commandments.webp",
+    "md": "tencommandments/readme.md",
+    "description": "Ten Commandments Applet for Tidbyt Displays one of the ten commandments.  You can pick one per day, ...",
+    "starFiles": [
+      "ten_commandments.star"
+    ]
+  },
+  {
+    "name": "tennisrankings",
+    "image": "tennisrankings/tennis_rankings.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tennis_rankings.star"
+    ]
+  },
+  {
+    "name": "teslafi",
+    "image": "teslafi/teslafi.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "teslafi.star"
+    ]
+  },
+  {
+    "name": "teslasolar",
+    "image": "teslasolar/teslasolar.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tesla_solar.star"
+    ]
+  },
+  {
+    "name": "tessie",
+    "image": "tessie/tessie.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tessie.star"
+    ]
+  },
+  {
+    "name": "testcricket",
+    "image": "testcricket/cricket2.gif",
+    "md": "testcricket/readme.md",
+    "description": "Similar to my other cricket apps, but this one is for test matches \r \r Select your team and it will ...",
+    "starFiles": [
+      "test_cricket.star"
+    ]
+  },
+  {
+    "name": "testpatterns",
+    "image": "testpatterns/example.png",
+    "md": "testpatterns/README.md",
+    "description": "Test Patterns Test patterns were broadcast on televisions at night, relics of a bygone era where we ...",
+    "starFiles": [
+      "test_patterns.star"
+    ]
+  },
+  {
+    "name": "tetrisclock",
+    "image": "tetrisclock/tetrisclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tetris_clock.star"
+    ]
+  },
+  {
+    "name": "text-regular",
+    "image": "text-regular/text-regular.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "text-regular.star"
+    ]
+  },
+  {
+    "name": "text-scrolling",
+    "image": "text-scrolling/text-scrolling.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "text-scrolling.star"
+    ]
+  },
+  {
+    "name": "text-title",
+    "image": "text-title/text-title.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "text-title.star"
+    ]
+  },
+  {
+    "name": "textbyt",
+    "image": "textbyt/messages.png",
+    "md": "textbyt/README.md",
+    "description": "Textbyt Applet for Tidbyt Display text messages on your Tidbyt. Great for parties or letting your lo...",
+    "starFiles": [
+      "textbyt.star"
+    ]
+  },
+  {
+    "name": "thanksgivingday",
+    "image": "thanksgivingday/thanksgivingday.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "thanksgiving_day.star"
+    ]
+  },
+  {
+    "name": "theguardiannews",
+    "image": "theguardiannews/theguardiannews.webp",
+    "md": "theguardiannews/README.md",
+    "description": "The Guardian News Headlines The Guardian News Headlines, uses the theguardian.com web content to dis...",
+    "starFiles": [
+      "theguardiannews.star"
+    ]
+  },
+  {
+    "name": "thetracker",
+    "image": "thetracker/_img1.png",
+    "md": "thetracker/README.md",
+    "description": "The Tracker Flexible Tidbyt counter to display your numbers via an ilo.so Counter ID. Show social & ...",
+    "starFiles": [
+      "the_tracker.star"
+    ]
+  },
+  {
+    "name": "theysaidso",
+    "image": "theysaidso/theysaidso.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "they_said_so.star"
+    ]
+  },
+  {
+    "name": "thingspeak",
+    "image": "thingspeak/ThingSpeakDemo.png",
+    "md": "thingspeak/README.md",
+    "description": "What is Thingspeak? ThingSpeak is an IoT analytics platform service that allows you to aggregate, vi...",
+    "starFiles": [
+      "thingspeak.star"
+    ]
+  },
+  {
+    "name": "thingswifesays",
+    "image": "thingswifesays/thingswifesays.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "things_wife_says.star"
+    ]
+  },
+  {
+    "name": "thisdayhistory",
+    "image": "thisdayhistory/thisdayhistory.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "this_day_history.star"
+    ]
+  },
+  {
+    "name": "thisisfine",
+    "image": "thisisfine/thisisfine.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "this_is_fine.star"
+    ]
+  },
+  {
+    "name": "thunderball",
+    "image": "thunderball/thunderball.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "thunderball.star"
+    ]
+  },
+  {
+    "name": "tidalgraph",
+    "image": "tidalgraph/TidalGraph - Screenshot.png",
+    "md": "tidalgraph/README.md",
+    "description": "TidalGraph for Tidbyt  Shows the tide height throughout the day of the ocean based on the selected N...",
+    "starFiles": [
+      "tidalgraph.star"
+    ]
+  },
+  {
+    "name": "tidbytapptrack",
+    "image": "tidbytapptrack/tidbytapptrack.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tidbyt_app_track.star"
+    ]
+  },
+  {
+    "name": "tidbytclocks",
+    "image": "tidbytclocks/tidbytclocks.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tidbyt_clocks.star"
+    ]
+  },
+  {
+    "name": "tidclock",
+    "image": "tidclock/tidclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tidclock.star"
+    ]
+  },
+  {
+    "name": "tiddlysynth",
+    "image": "tiddlysynth/tiddlysynth.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tiddlysynth.star"
+    ]
+  },
+  {
+    "name": "tidesandtemp",
+    "image": "tidesandtemp/tidesandtemp.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tides_and_temp.star"
+    ]
+  },
+  {
+    "name": "tilthydrometer",
+    "image": "tilthydrometer/tilthydrometer.webp",
+    "md": "tilthydrometer/readme.md",
+    "description": "Tilt Hydrometer The Tilt Hydometer logs and tracks data throughout fermentation via Bluetooth. Log d...",
+    "starFiles": [
+      "tilt_hydrometer.star"
+    ]
+  },
+  {
+    "name": "timeandweather",
+    "image": "timeandweather/timeandweather.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "time_and_weather.star"
+    ]
+  },
+  {
+    "name": "timer",
+    "image": "timer/timer.gif",
+    "md": "timer/README.md",
+    "description": "Timer A timer for Tidbyt! Displayed: A progress bar for the timer A timer Options: Adjust the hours ...",
+    "starFiles": [
+      "timer.star"
+    ]
+  },
+  {
+    "name": "timeularactivity",
+    "image": "timeularactivity/timeularactivity.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "timeular_activity.star"
+    ]
+  },
+  {
+    "name": "timeuntil",
+    "image": "timeuntil/time_until.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "time_until.star"
+    ]
+  },
+  {
+    "name": "tindiesales",
+    "image": "tindiesales/screenshot.png",
+    "md": "tindiesales/README.md",
+    "description": "Tindie Sales Applet for Tidbyt Tindie is an online marketplace for maker-made products. This applet ...",
+    "starFiles": [
+      "tindie_sales.star"
+    ]
+  },
+  {
+    "name": "tixclock",
+    "image": "tixclock/tix_clock_1235.webp",
+    "md": "tixclock/README.md",
+    "description": "TIX Clock for Tidbyt Displays the time using colorful blocks. Choose 12/24 display as well as pick f...",
+    "starFiles": [
+      "tix_clock.star"
+    ]
+  },
+  {
+    "name": "todayinhistory",
+    "image": "todayinhistory/today_in_history.gif",
+    "md": "todayinhistory/README.md",
+    "description": "Today in history This applet looks at Wikipedia for events for the current date, and parses them int...",
+    "starFiles": [
+      "today_in_history.star"
+    ]
+  },
+  {
+    "name": "todayonkawara",
+    "image": "todayonkawara/today_on_kawara.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "today_on_kawara.star"
+    ]
+  },
+  {
+    "name": "todoist",
+    "image": "todoist/customize.png",
+    "md": "todoist/README.md",
+    "description": "Todoist Integration for Tidbyt Todoist is a to-do list and task manager for professionals and small ...",
+    "starFiles": [
+      "todoist.star"
+    ]
+  },
+  {
+    "name": "todoistnext",
+    "image": "todoistnext/todoist_next.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "todoist_next.star"
+    ]
+  },
+  {
+    "name": "todoistroutines",
+    "image": "todoistroutines/screenshot-bg-color.png",
+    "md": "todoistroutines/README.md",
+    "description": "Todoist Routines for Tidbyt Shows today's remaining tasks and subtasks as minimalist rows or columns...",
+    "starFiles": [
+      "todoist_routines.star"
+    ]
+  },
+  {
+    "name": "todoisttasks",
+    "image": "todoisttasks/todoisttasks.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "todoisttasks.star"
+    ]
+  },
+  {
+    "name": "top10books",
+    "image": "top10books/example.png",
+    "md": "top10books/README.md",
+    "description": "Top 10 Books (Barnes & Noble) Fetch the top 10 books from the Barnes & Noble top 100 page.  Randomly...",
+    "starFiles": [
+      "top_10_books.star"
+    ]
+  },
+  {
+    "name": "topcryptoprices",
+    "image": "topcryptoprices/top_crypto_prices.gif",
+    "md": "topcryptoprices/README.md",
+    "description": "Top Crypto Prices This app shows the latest prices and 24hr price changes for the top cryptocurrenci...",
+    "starFiles": [
+      "top_crypto_prices.star"
+    ]
+  },
+  {
+    "name": "traffic",
+    "image": "traffic/traffic.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "traffic.star"
+    ]
+  },
+  {
+    "name": "trakt",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "trakt.star"
+    ]
+  },
+  {
+    "name": "trambyt",
+    "image": "trambyt/trambyt.png",
+    "md": "trambyt/README.md",
+    "description": "Trambyt Shows upcoming departures from Västtrafik, western Sweden public transport. The use can conf...",
+    "starFiles": [
+      "trambyt.star"
+    ]
+  },
+  {
+    "name": "transsee",
+    "image": "transsee/transsee.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "transsee.star"
+    ]
+  },
+  {
+    "name": "trash",
+    "image": "trash/trash.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "trash.star"
+    ]
+  },
+  {
+    "name": "trashbinsout",
+    "image": "trashbinsout/trashbinsout.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "trashbinsout.star"
+    ]
+  },
+  {
+    "name": "trashrecbinsout",
+    "image": "trashrecbinsout/trashrecbinsout.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "trashrecbinsout.star"
+    ]
+  },
+  {
+    "name": "trashrecycle",
+    "image": "trashrecycle/trashrecycle.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "trashrecycle.star"
+    ]
+  },
+  {
+    "name": "trimetarrivals",
+    "image": null,
+    "md": "trimetarrivals/README.md",
+    "description": "TriMet stop next arrivals — realtim Simple app to display the arrival time of the next bus at a  giv...",
+    "starFiles": [
+      "trimet_arrivals.star"
+    ]
+  },
+  {
+    "name": "trimetstops",
+    "image": "trimetstops/trimet_stops.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "trimet_stops.star"
+    ]
+  },
+  {
+    "name": "trivia",
+    "image": "trivia/trivia.gif",
+    "md": "trivia/README.md",
+    "description": "Trivia Applet for Tidbyt Displays a random trivia question with category and difficulty. Trivia API:...",
+    "starFiles": [
+      "trivia.star"
+    ]
+  },
+  {
+    "name": "trolley_detector",
+    "image": "trolley_detector/trolley_detector.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "trolley_detector.star"
+    ]
+  },
+  {
+    "name": "tube",
+    "image": "tube/tube.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tube.star"
+    ]
+  },
+  {
+    "name": "tubestatus",
+    "image": "tubestatus/problems_first.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tube_status.star"
+    ]
+  },
+  {
+    "name": "tvquotes",
+    "image": "tvquotes/tvquotes.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tv_quotes.star"
+    ]
+  },
+  {
+    "name": "tvstatic",
+    "image": "tvstatic/tvstatic.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tv_static.star"
+    ]
+  },
+  {
+    "name": "twbaseballcpbl",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "tw_baseball_cpbl.star"
+    ]
+  },
+  {
+    "name": "twitch",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "twitch.star"
+    ]
+  },
+  {
+    "name": "twsestock",
+    "image": "twsestock/twsestock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "twse_stock.star"
+    ]
+  },
+  {
+    "name": "uflscores",
+    "image": "uflscores/screenshot.png",
+    "md": "uflscores/README.md",
+    "description": "UFL Scores for Tidbyt Displays live UFL scores and gambling odds for upcoming games. Updated every 2...",
+    "starFiles": [
+      "ufl_scores.star"
+    ]
+  },
+  {
+    "name": "ukelections",
+    "image": "ukelections/uk_elections.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "uk_elections.star"
+    ]
+  },
+  {
+    "name": "ukpolling",
+    "image": "ukpolling/30_days.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "uk_polling.star"
+    ]
+  },
+  {
+    "name": "underwaterclock",
+    "image": "underwaterclock/underwaterclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "underwater_clock.star"
+    ]
+  },
+  {
+    "name": "universalical",
+    "image": "universalical/universalical.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "universal_ical.star"
+    ]
+  },
+  {
+    "name": "unixepochclock",
+    "image": "unixepochclock/unixepochclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "unix_epoch_clock.star"
+    ]
+  },
+  {
+    "name": "unleashed",
+    "image": "unleashed/unleashed.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "unleashed.star"
+    ]
+  },
+  {
+    "name": "unsplash",
+    "image": "unsplash/unsplash.webp",
+    "md": "unsplash/README.md",
+    "description": "Unsplash Integration for Tidbyt Unsplash provides beautiful, free images and photos that you can dow...",
+    "starFiles": [
+      "unsplash.star"
+    ]
+  },
+  {
+    "name": "upcoming_events",
+    "image": "upcoming_events/upcoming_events.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "upcoming_events.star"
+    ]
+  },
+  {
+    "name": "updownio",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "updownio.star"
+    ]
+  },
+  {
+    "name": "us_electoral_forecast",
+    "image": "us_electoral_forecast/us_electoral_forecast.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "us_electoral_forecast.star"
+    ]
+  },
+  {
+    "name": "us_polling_average",
+    "image": "us_polling_average/us_polling_average.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "us_polling_average.star"
+    ]
+  },
+  {
+    "name": "usdebtclock",
+    "image": "usdebtclock/usdebtclock.webp",
+    "md": "usdebtclock/README.md",
+    "description": "US Debt Clock Applet for Tidbyt Displays the total debt by the United States of America in dollars. ...",
+    "starFiles": [
+      "usdebtclock.star"
+    ]
+  },
+  {
+    "name": "usgsearthquakes",
+    "image": "usgsearthquakes/usgsearthquakes.webp",
+    "md": "usgsearthquakes/README.md",
+    "description": "USGS Earthquakes Applet for Tidbyt Displays up to three earthquakes that have occurred during the pa...",
+    "starFiles": [
+      "usgs_earthquakes.star"
+    ]
+  },
+  {
+    "name": "usmortgagerates",
+    "image": "usmortgagerates/screenshot.png",
+    "md": "usmortgagerates/README.md",
+    "description": "Average US Mortgage Rates Tracker <img src=\"./screenshot.png\" width=\"450\" border=\"10\"> Configuration...",
+    "starFiles": [
+      "us_mortgage_rates.star"
+    ]
+  },
+  {
+    "name": "usyieldcurve",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "us_yield_curve.star"
+    ]
+  },
+  {
+    "name": "uv",
+    "image": "uv/uv.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "uv.star"
+    ]
+  },
+  {
+    "name": "valorantstats",
+    "image": "valorantstats/valorant_stats.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "valorant_stats.star"
+    ]
+  },
+  {
+    "name": "valyrianglyphs",
+    "image": "valyrianglyphs/valyrianglyphs.webp",
+    "md": "valyrianglyphs/README.md",
+    "description": "Valyrian Glyphs for Tidbyt Display a random glyph and translations from the High Valyrian language, ...",
+    "starFiles": [
+      "valyrian_glyphs.star"
+    ]
+  },
+  {
+    "name": "vatsimapp",
+    "image": "vatsimapp/vatsimapp.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "vatsimapp.star"
+    ]
+  },
+  {
+    "name": "verceldashboard",
+    "image": "verceldashboard/screenshot.png",
+    "md": "verceldashboard/README.md",
+    "description": "Vercel Dashboard !Vercel Dashboard This Vercel dashboard allows you to see the latest deployment and...",
+    "starFiles": [
+      "vercel_dashboard.star"
+    ]
+  },
+  {
+    "name": "vergetaglines",
+    "image": "vergetaglines/vergetaglines.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "verge_taglines.star"
+    ]
+  },
+  {
+    "name": "verticalmessage",
+    "image": "verticalmessage/verticalmessage.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "vertical_message.star"
+    ]
+  },
+  {
+    "name": "vgknextgame",
+    "image": "vgknextgame/vgk_next_game.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "vgk_next_game.star"
+    ]
+  },
+  {
+    "name": "victron",
+    "image": "victron/victron.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "victron.star"
+    ]
+  },
+  {
+    "name": "vidiotscalendar",
+    "image": "vidiotscalendar/vidiotscalendar.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "vidiots_calendar.star"
+    ]
+  },
+  {
+    "name": "viepubltransp",
+    "image": "viepubltransp/display1.png",
+    "md": "viepubltransp/README.md",
+    "description": "Real Time Departures for Public Transport Stops in Vienna With this app, users can choose up to for ...",
+    "starFiles": [
+      "viepubltransp.star"
+    ]
+  },
+  {
+    "name": "vipabfahrten",
+    "image": "vipabfahrten/vipabfahrten.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "vipabfahrten.star"
+    ]
+  },
+  {
+    "name": "virtualpets",
+    "image": "virtualpets/virtualpets.webp",
+    "md": "virtualpets/README.md",
+    "description": "Virtual Pets for Tidbyt Choose and name your own pet while watching the environment change with the ...",
+    "starFiles": [
+      "virtual_pets.star"
+    ]
+  },
+  {
+    "name": "visibleplanets",
+    "image": "visibleplanets/visibleplanets.webp",
+    "md": "visibleplanets/readme.md",
+    "description": "VisiblePlanets for Tidbyt Pick a planet, and this app will display information on the direction you ...",
+    "starFiles": [
+      "visibleplanets.star"
+    ]
+  },
+  {
+    "name": "visualcrossingweather",
+    "image": "visualcrossingweather/visualcrossing_weather.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "visualcrossing_weather.star"
+    ]
+  },
+  {
+    "name": "visualizercoffee",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "visualizercoffee.star"
+    ]
+  },
+  {
+    "name": "vitaloccupancy",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "vital_occupancy.star"
+    ]
+  },
+  {
+    "name": "wanikanireminder",
+    "image": "wanikanireminder/wanikanireminder.webp",
+    "md": "wanikanireminder/README.md",
+    "description": "WaniKani Reminders A simple app for displaying your available WaniKani lessons and reviews similar t...",
+    "starFiles": [
+      "wanikani_reminder.star"
+    ]
+  },
+  {
+    "name": "wantedposter",
+    "image": "wantedposter/wanted_default.webp",
+    "md": "wantedposter/readme.md",
+    "description": "Wanted Poster for Tidbyt Shock your friends and family, have them appear on a wanted poster as your ...",
+    "starFiles": [
+      "wantedposter.star"
+    ]
+  },
+  {
+    "name": "warframecycles",
+    "image": "warframecycles/warframecycles.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "warframe_cycles.star"
+    ]
+  },
+  {
+    "name": "washer",
+    "image": "washer/washer.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "washer.star"
+    ]
+  },
+  {
+    "name": "wbcscores",
+    "image": "wbcscores/screenshot.png",
+    "md": "wbcscores/README.md",
+    "description": "MLB Scores for Tidbyt Displays live MLB scores and gambling odds for upcoming games. Updated every 2...",
+    "starFiles": [
+      "wbc_scores.star"
+    ]
+  },
+  {
+    "name": "weather",
+    "image": "weather/weather.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "weather.star"
+    ]
+  },
+  {
+    "name": "weatherbard",
+    "image": "weatherbard/weatherbard.webp",
+    "md": "weatherbard/README.md",
+    "description": "Weatherbard Weatherbard combines real-time weather data with poetic reflections drawn from a Mary Ol...",
+    "starFiles": [
+      "weatherbard.star"
+    ]
+  },
+  {
+    "name": "weatherclock",
+    "image": "weatherclock/weatherclock.gif",
+    "md": "weatherclock/README.md",
+    "description": "Weather Clock --- This app renders the time and current weather for your location. The weather is ob...",
+    "starFiles": [
+      "weatherclock.star"
+    ]
+  },
+  {
+    "name": "weatherdashboard",
+    "image": "weatherdashboard/weatherdashboard.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "weather_dashboard.star"
+    ]
+  },
+  {
+    "name": "weathermap",
+    "image": "weathermap/weathermap.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "weather_map.star"
+    ]
+  },
+  {
+    "name": "weathersnapshot",
+    "image": "weathersnapshot/weather_snapshot.gif",
+    "md": "weathersnapshot/README.md",
+    "description": "Weather Snapshot Overview The Weather Snapshot app displays current temperature, humidity, and AQI d...",
+    "starFiles": [
+      "weather_snapshot.star"
+    ]
+  },
+  {
+    "name": "weatherstem",
+    "image": "weatherstem/weatherstem.webp",
+    "md": "weatherstem/README.md",
+    "description": "WeatherSTEM --- This app renders the current weather conditions from any WeatherSTEM weather station...",
+    "starFiles": [
+      "weatherstem.star"
+    ]
+  },
+  {
+    "name": "web3counter",
+    "image": "web3counter/web3counter.webp",
+    "md": "web3counter/README.md",
+    "description": "Web 3 Counter Web 3 Is Going Great Polls W3IGG for the current amount of money lost and displays it....",
+    "starFiles": [
+      "web_3_counter.star"
+    ]
+  },
+  {
+    "name": "weightgurus",
+    "image": "weightgurus/weight_gurus.gif",
+    "md": "weightgurus/README.md",
+    "description": "Weight Gurus Applet for Tidbyt Displays your most recent weigh-in from a Weight Gurus smart scale, a...",
+    "starFiles": [
+      "weight_gurus.star"
+    ]
+  },
+  {
+    "name": "wfmu",
+    "image": "wfmu/wfmu.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "wfmu.star"
+    ]
+  },
+  {
+    "name": "whatthecommit",
+    "image": "whatthecommit/whatthecommit.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "whatthecommit.star"
+    ]
+  },
+  {
+    "name": "whosthatpokemon",
+    "image": "whosthatpokemon/wtp-preview.png",
+    "md": "whosthatpokemon/README.md",
+    "description": "Who's That Pokemon? Shows you the silhouette of a Pokemon for half of your tidbyt's display duration...",
+    "starFiles": [
+      "whosthatpokemon.star"
+    ]
+  },
+  {
+    "name": "wienerlinieninfo",
+    "image": "wienerlinieninfo/wienerlinien_info.gif",
+    "md": "wienerlinieninfo/README.md",
+    "description": "Tidbyt Wiener Linien Info app Hi!! Thanks for your interest in this application.  This App is a simp...",
+    "starFiles": [
+      "wienerlinien_info.star"
+    ]
+  },
+  {
+    "name": "wifiqrcode",
+    "image": "wifiqrcode/wifi_qr_code.gif",
+    "md": "wifiqrcode/README.md",
+    "description": "WiFi QR Code Generator App for Tidbyt A WiFi QR code app for the Tidbyt. This app creates a scannabl...",
+    "starFiles": [
+      "wifi_qr_code.star"
+    ]
+  },
+  {
+    "name": "wikifeatimage",
+    "image": "wikifeatimage/wikifeatimage.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "wiki_feat_image.star"
+    ]
+  },
+  {
+    "name": "wikipagetoday",
+    "image": "wikipagetoday/wikipagetoday.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "wiki_page_today.star"
+    ]
+  },
+  {
+    "name": "windytron",
+    "image": "windytron/windytron.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "windytron.star"
+    ]
+  },
+  {
+    "name": "wmata_buses",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "wmata_buses.star"
+    ]
+  },
+  {
+    "name": "wnbascores",
+    "image": "wnbascores/screenshot.png",
+    "md": "wnbascores/README.md",
+    "description": "WNBA Scores for Tidbyt Displays live WNBA scores and gambling odds for upcoming games. Updated every...",
+    "starFiles": [
+      "wnba_scores.star"
+    ]
+  },
+  {
+    "name": "wnyc",
+    "image": "wnyc/wnyc.webp",
+    "md": "wnyc/README.md",
+    "description": "WNYC Show what's currently playing on WNYC on Tidbyt Settings You can change the following settings:...",
+    "starFiles": [
+      "wnyc.star"
+    ]
+  },
+  {
+    "name": "womenst20wc",
+    "image": null,
+    "md": "womenst20wc/readme.md",
+    "description": "A little bit different from the other T20 cricket apps I've made. This one gets its initial match in...",
+    "starFiles": [
+      "womens_t20_wc.star"
+    ]
+  },
+  {
+    "name": "woocommercestats",
+    "image": "woocommercestats/woocommercestats.png",
+    "md": "woocommercestats/README.md",
+    "description": "WooCommerce Stats for Tidbyt Displays stats for your WooCommerce store including number of orders an...",
+    "starFiles": [
+      "woocommerce_stats.star"
+    ]
+  },
+  {
+    "name": "wordclock",
+    "image": "wordclock/wordclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "word_clock.star"
+    ]
+  },
+  {
+    "name": "wordlebyt",
+    "image": "wordlebyt/screenshot.png",
+    "md": "wordlebyt/README.md",
+    "description": "Wordle Score Applet for Tidbyt Displays the current Wordle Score that you've pasted into Wordlebyt f...",
+    "starFiles": [
+      "wordlebyt.star"
+    ]
+  },
+  {
+    "name": "wordoftheday",
+    "image": "wordoftheday/screenshot.png",
+    "md": "wordoftheday/README.md",
+    "description": "Word Of The Day Applet for Tidbyt --- Displays the Merriam-Webster Word Of The Day. Word and definit...",
+    "starFiles": [
+      "word_of_the_day.star"
+    ]
+  },
+  {
+    "name": "worldcapitals",
+    "image": "worldcapitals/screenshot.png",
+    "md": "worldcapitals/README.md",
+    "description": "World Capitals Displays a country and its capital once per day. Choose to cycle between all countrie...",
+    "starFiles": [
+      "worldcapitals.star"
+    ]
+  },
+  {
+    "name": "worldclock",
+    "image": "worldclock/worldclock.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "world_clock.star"
+    ]
+  },
+  {
+    "name": "worldtides",
+    "image": "worldtides/worldtides.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "world_tides.star"
+    ]
+  },
+  {
+    "name": "wowcharacterstats",
+    "image": "wowcharacterstats/screenshot.png",
+    "md": "wowcharacterstats/README.md",
+    "description": "WoW Character Stats for Tidbyt Show statistics for a World of Warcraft character.  Stats shown inclu...",
+    "starFiles": [
+      "wowcharacterstats.star"
+    ]
+  },
+  {
+    "name": "wowtoken",
+    "image": "wowtoken/screenshot.png",
+    "md": "wowtoken/README.md",
+    "description": "WoW Token Applet for Tidbyt Displays the current price of the World of Warcraft token in various reg...",
+    "starFiles": [
+      "wow_token.star"
+    ]
+  },
+  {
+    "name": "wqxr",
+    "image": "wqxr/wqxr.webp",
+    "md": "wqxr/README.md",
+    "description": "WQXR Show what's currently playing on WQXR, New York's Classical Music Radio Station, on your Tidbyt...",
+    "starFiles": [
+      "wqxr.star"
+    ]
+  },
+  {
+    "name": "wrigleyclock",
+    "image": "wrigleyclock/wrigley_clock.png",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "wrigley_clock.star"
+    ]
+  },
+  {
+    "name": "wsjnews",
+    "image": "wsjnews/wsj_news.gif",
+    "md": "wsjnews/README.md",
+    "description": "Wall Street Journal News Headlines Wall Street Journal news headlines displays current headline arti...",
+    "starFiles": [
+      "wsj_news.star"
+    ]
+  },
+  {
+    "name": "wsonedevbytype",
+    "image": "wsonedevbytype/wsonedevbytypep.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "wsonedevbytypep.star"
+    ]
+  },
+  {
+    "name": "wsonedevices",
+    "image": "wsonedevices/wsonedevicesp.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "wsonedevicesp.star"
+    ]
+  },
+  {
+    "name": "wtatennis",
+    "image": "wtatennis/wta_tennis.gif",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "wta_tennis.star"
+    ]
+  },
+  {
+    "name": "xboxgamerscore",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "xbox_gamerscore.star"
+    ]
+  },
+  {
+    "name": "xboxplaydates",
+    "image": null,
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "xboxplaydates.star"
+    ]
+  },
+  {
+    "name": "xflscores",
+    "image": "xflscores/screenshot.png",
+    "md": "xflscores/README.md",
+    "description": "XFL Scores for Tidbyt Displays live XFL scores and gambling odds for upcoming games. Updated every 2...",
+    "starFiles": [
+      "xfl_scores.star"
+    ]
+  },
+  {
+    "name": "xscreensaver",
+    "image": "xscreensaver/xscreensaver.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "xscreensaver.star"
+    ]
+  },
+  {
+    "name": "xtrabyt",
+    "image": "xtrabyt/xtrabyt.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "xtrabyt.star"
+    ]
+  },
+  {
+    "name": "yahoofantasybaseball",
+    "image": "yahoofantasybaseball/yahoofantasymlb.gif",
+    "md": "yahoofantasybaseball/README.md",
+    "description": "Yahoo Fantasy Baseball App Shows information from a Yahoo Fantasy Baseball league. The app can be mo...",
+    "starFiles": [
+      "yahoofantasymlb.star"
+    ]
+  },
+  {
+    "name": "yahoofantasyfootball",
+    "image": "yahoofantasyfootball/yahoofantasynfl.gif",
+    "md": "yahoofantasyfootball/README.md",
+    "description": "Yahoo Fantasy Football App Shows information from a Yahoo Fantasy Football league. The app can be mo...",
+    "starFiles": [
+      "yahoofantasynfl.star"
+    ]
+  },
+  {
+    "name": "yearprogress",
+    "image": "yearprogress/yearprogress.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "year_progress.star"
+    ]
+  },
+  {
+    "name": "ynab",
+    "image": "ynab/YNAB-Transactions.webp",
+    "md": "ynab/README.md",
+    "description": "Welcome to the YNAB Tidbyt App! This app uses the YNAB API (https://api.youneedabudget.com/v1#/) to ...",
+    "starFiles": [
+      "ynab.star"
+    ]
+  },
+  {
+    "name": "yulelog",
+    "image": "yulelog/yulelog.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "yule_log.star"
+    ]
+  },
+  {
+    "name": "zapier",
+    "image": "zapier/zapier.webp",
+    "md": null,
+    "description": null,
+    "starFiles": [
+      "zapier.star"
+    ]
+  },
+  {
+    "name": "zenhub",
+    "image": "zenhub/zenhub.webp",
+    "md": "zenhub/README.md",
+    "description": "tidbyt-zenhub Connect your Zenhub workspace and keep track of your issues using your Tidbyt display ...",
+    "starFiles": [
+      "zenhub.star"
+    ]
+  },
+  {
+    "name": "zmanim",
+    "image": "zmanim/zmanim.webp",
+    "md": "zmanim/README.md",
+    "description": "Tidbyt Zmanim App Display Jewish prayer times (zmanim) on your Tidbyt device. Shows important daily ...",
+    "starFiles": [
+      "zmanim.star"
+    ]
+  }
+]

--- a/app-viewer/generate-apps-json.js
+++ b/app-viewer/generate-apps-json.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const path = require('path');
+
+const APPS_DIR = path.join(__dirname, '../apps');
+const OUTPUT_FILE = path.join(__dirname, 'apps.json');
+const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
+const MD_FILES = ['README.md', 'readme.md', 'index.md'];
+
+function findFirstImage(files) {
+  return files.find(f => IMAGE_EXTS.includes(path.extname(f).toLowerCase()));
+}
+
+function findMarkdown(files) {
+  return files.find(f => MD_FILES.includes(f));
+}
+
+function getReadmeDescription(appPath, mdFile) {
+  try {
+    const mdPath = path.join(appPath, mdFile);
+    const content = fs.readFileSync(mdPath, 'utf8');
+    // Remove markdown formatting and get first 100 chars
+    const plainText = content
+      .replace(/#{1,6}\s+/g, '') // Remove headers
+      .replace(/\*\*(.*?)\*\*/g, '$1') // Remove bold
+      .replace(/\*(.*?)\*/g, '$1') // Remove italic
+      .replace(/\[(.*?)\]\(.*?\)/g, '$1') // Remove links
+      .replace(/`(.*?)`/g, '$1') // Remove inline code
+      .replace(/^\s*[-*+]\s+/gm, '') // Remove list markers
+      .replace(/\n+/g, ' ') // Replace newlines with spaces
+      .trim();
+
+    return plainText.length > 100 ? plainText.substring(0, 100) + '...' : plainText;
+  } catch {
+    return null;
+  }
+}
+
+function scanApps() {
+  const apps = [];
+  const appDirs = fs.readdirSync(APPS_DIR, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => dirent.name);
+
+  for (const appName of appDirs) {
+    const appPath = path.join(APPS_DIR, appName);
+    let files;
+    try {
+      files = fs.readdirSync(appPath);
+    } catch {
+      continue;
+    }
+    const image = findFirstImage(files);
+    const md = findMarkdown(files);
+    const starFiles = files.filter(f => f.endsWith('.star'));
+    const description = md ? getReadmeDescription(appPath, md) : null;
+
+    apps.push({
+      name: appName,
+      image: image ? `${appName}/${image}` : null,
+      md: md ? `${appName}/${md}` : null,
+      description: description,
+      starFiles: starFiles
+    });
+  }
+  return apps;
+}
+
+function main() {
+  const apps = scanApps();
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(apps, null, 2));
+  console.log(`Generated ${OUTPUT_FILE} with ${apps.length} apps.`);
+}
+
+main();

--- a/app-viewer/index.html
+++ b/app-viewer/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Apps Viewer</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+        <link rel="stylesheet" href="style.css">
+    </head>
+
+    <body>
+        <div class="container py-4">
+            <h1 class="mb-4"
+                style="font-family: 'Press Start 2P', monospace; color: #ffd700; text-shadow: 2px 2px 0 #000;">Apps
+                Viewer</h1>
+
+            <input type="text" id="search" class="form-control mb-4" placeholder="Search apps...">
+            <div id="apps-list" class="row g-4"></div>
+        </div>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+        <script src="main.js"></script>
+    </body>
+
+</html>

--- a/app-viewer/main.js
+++ b/app-viewer/main.js
@@ -1,0 +1,193 @@
+// --- CONFIG ---
+const APPS_DIR = '../apps';
+const IMAGE_EXTS = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
+const MD_FILES = ['README.md', 'readme.md', 'index.md'];
+const BROKEN_APPS_FILE = '../broken_apps.txt';
+
+// --- INDEX PAGE LOGIC ---
+async function fetchBrokenApps() {
+  try {
+    const res = await fetch(BROKEN_APPS_FILE);
+    if (res.ok) {
+      const text = await res.text();
+      return text.split('\n').map(line => line.trim()).filter(line => line);
+    }
+  } catch (e) {
+    console.error('Failed to load broken apps:', e);
+  }
+  return [];
+}
+
+async function fetchAppsList() {
+  // Load the generated apps.json file
+  try {
+    const res = await fetch('apps.json');
+    if (res.ok) {
+      return await res.json();
+    }
+  } catch (e) {
+    console.error('Failed to load apps.json:', e);
+  }
+  return [];
+}
+
+function renderAppsList(apps, brokenApps = []) {
+  const list = document.getElementById('apps-list');
+  list.innerHTML = '';
+  apps.forEach(app => {
+    const card = document.createElement('div');
+    card.className = 'col-md-4';
+    // Check if any of the app's star files are in the broken apps list
+    const isBroken = app.starFiles && app.starFiles.some(starFile => brokenApps.includes(starFile));
+    let buttonHtml;
+    if (app.md) {
+      buttonHtml = `<a href="app.html?app=${encodeURIComponent(app.name)}" class="btn btn-primary mt-auto">📄 View Details</a>`;
+    } else {
+      buttonHtml = `<button class="btn btn-secondary mt-auto" disabled>🚫 No Details</button>`;
+    }
+
+    let imageHtml;
+    if (app.image) {
+      imageHtml = `<img src="${APPS_DIR}/${app.image}" class="card-img-top" alt="${app.name}">`;
+    } else {
+      imageHtml = `<div class="card-img-top d-flex align-items-center justify-content-center bg-secondary text-white">No Image</div>`;
+    }
+
+    card.innerHTML = `
+      <div class="card h-100">
+        <div class="position-relative">
+          ${imageHtml}
+          ${isBroken ? '<div class="broken-badge" title="This app is marked as broken" data-bs-toggle="tooltip">⚠️</div>' : ''}
+        </div>
+        <div class="card-body d-flex flex-column">
+          <h5 class="card-title">${app.name}${isBroken ? ' <span class="text-warning" title="Broken app" data-bs-toggle="tooltip">⚠️</span>' : ''}</h5>
+          ${app.description ? `<p class="card-description small mb-3">${app.description}</p>` : ''}
+          ${buttonHtml}
+        </div>
+      </div>
+    `;
+    list.appendChild(card);
+  });
+
+  // Initialize tooltips
+  const tooltips = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+  tooltips.forEach(tooltip => {
+    new bootstrap.Tooltip(tooltip, {
+      customClass: 'tooltip-custom'
+    });
+  });
+}
+
+function setupSearch(apps, brokenApps) {
+  const search = document.getElementById('search');
+  search.addEventListener('input', () => {
+    const val = search.value.toLowerCase();
+    renderAppsList(apps.filter(app => app.name.toLowerCase().includes(val)), brokenApps);
+  });
+}
+
+// --- APP DETAIL PAGE LOGIC ---
+async function fetchAppMarkdown(appName) {
+  // Try to fetch the markdown file
+  for (const mdFile of MD_FILES) {
+    try {
+      const res = await fetch(`${APPS_DIR}/${appName}/${mdFile}`);
+      if (res.ok) return await res.text();
+    } catch {}
+  }
+  return null;
+}
+
+function getAppNameFromURL() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('app');
+}
+
+async function renderAppDetail() {
+  const appName = getAppNameFromURL();
+  const container = document.getElementById('app-content');
+  if (!appName) {
+    container.innerHTML = '<div class="alert alert-danger">App not specified.</div>';
+    return;
+  }
+
+  // Get app data and check if app is broken
+  const apps = await fetchAppsList();
+  const app = apps.find(a => a.name === appName);
+  const brokenApps = await fetchBrokenApps();
+  const isBroken = app && app.starFiles && app.starFiles.some(starFile => brokenApps.includes(starFile));
+
+  const md = await fetchAppMarkdown(appName);
+  let content = '';
+
+  if (isBroken) {
+    content += '<div class="alert alert-warning"><strong><span title="This app has been reported as broken" data-bs-toggle="tooltip">⚠️</span> This app is marked as broken</strong></div>';
+  }
+
+  if (md) {
+    try {
+      // Custom renderer to fix image paths
+      const renderer = new marked.Renderer();
+      renderer.image = function(href, title, text) {
+        // Handle both old and new marked.js API
+        if (typeof href === 'object' && href !== null) {
+          // New API: href is a token object
+          const token = href;
+          href = token.href;
+          title = token.title;
+          text = token.text;
+        }
+
+        // If href is relative, prefix with correct app path
+        if (href && typeof href === 'string' && !href.match(/^(https?:\/\/|\/|apps\/)/)) {
+          href = `../apps/${appName}/${href}`;
+        }
+        let out = `<img src="${href || ''}" alt="${text || ''}"`;
+        if (title) out += ` title="${title}"`;
+        out += ' />';
+        return out;
+      };
+      content += marked.parse(md, { renderer });
+    } catch (error) {
+      console.error('Marked.js error:', error);
+      content += '<div class="alert alert-danger">Error rendering markdown: ' + error.message + '</div>';
+      content += '<pre>' + md + '</pre>'; // Show raw markdown as fallback
+    }
+  } else {
+    content += '<div class="alert alert-warning">No documentation available.</div>';
+  }
+
+  // Add Report Broken button
+  const reportUrl = `https://github.com/tronbyt/apps/issues/new?title=Report%20Broken%20App:%20${encodeURIComponent(appName)}&body=The%20app%20%60${encodeURIComponent(appName)}%60%20appears%20to%20be%20broken.%0A%0APlease%20add%20the%20appropriate%20.star%20file%20to%20the%20%60broken_apps.txt%60%20file.`;
+  content += `
+    <div class="mt-4 pt-4 border-top">
+      <a href="${reportUrl}" target="_blank" class="btn btn-warning" style="font-family: 'Press Start 2P', monospace;">
+        ${isBroken ? '⚠️ Already Reported' : '🐛 Report Broken'}
+      </a>
+    </div>
+  `;
+
+  container.innerHTML = content;
+
+  // Initialize tooltips for the app detail page
+  const tooltips = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+  tooltips.forEach(tooltip => {
+    new bootstrap.Tooltip(tooltip, {
+      customClass: 'tooltip-custom'
+    });
+  });
+}
+
+// --- INIT ---
+document.addEventListener('DOMContentLoaded', async () => {
+  if (document.getElementById('apps-list')) {
+    // Index page
+    const apps = await fetchAppsList();
+    const brokenApps = await fetchBrokenApps();
+    renderAppsList(apps, brokenApps);
+    setupSearch(apps, brokenApps);
+  } else if (document.getElementById('app-content')) {
+    // App detail page
+    renderAppDetail();
+  }
+});

--- a/app-viewer/package.json
+++ b/app-viewer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "tronbyt-apps-viewer",
+  "version": "1.0.0",
+  "description": "Static web viewer for Tronbyt apps with search and documentation",
+  "main": "generate-apps-json.js",
+  "scripts": {
+    "build": "node generate-apps-json.js",
+    "serve": "python3 -m http.server 8080"
+  },
+  "keywords": [
+    "tidbyt",
+    "pixlet",
+    "apps",
+    "viewer",
+    "static-site"
+  ],
+  "author": "Tronbyt Apps",
+  "license": "MIT",
+  "engines": {
+    "node": ">=16.0.0"
+  }
+}

--- a/app-viewer/style.css
+++ b/app-viewer/style.css
@@ -1,0 +1,127 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+body {
+  background: #181818;
+  color: #e0e0e0;
+  font-family: 'Press Start 2P', monospace;
+}
+
+.card {
+  background: #222;
+  border: 2px solid #444;
+  min-height: 350px;
+  box-shadow: 0 2px 8px #000a;
+}
+
+.card-text {
+  font-size: 0.8rem;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.card-description {
+  color: #bbb !important;
+  font-size: 0.8rem;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.card-title {
+  color: #ffd700;
+  font-size: 1rem;
+  text-shadow: 1px 1px 0 #000;
+}
+
+.btn-primary {
+  background: #3333cc;
+  border: none;
+  color: #fff;
+  font-family: 'Press Start 2P', monospace;
+}
+.btn-secondary {
+  background: #444;
+  border: none;
+  color: #aaa;
+  font-family: 'Press Start 2P', monospace;
+}
+
+.form-control {
+  background: #222;
+  color: #ffd700;
+  border: 2px solid #333;
+  font-family: 'Press Start 2P', monospace;
+}
+
+.card-img-top {
+  object-fit: cover;
+  height: 180px;
+  background: #111;
+  border-bottom: 2px solid #444;
+}
+
+#app-content img {
+  max-width: 100%;
+  height: auto;
+  image-rendering: pixelated;
+  border: 2px solid #333;
+  background: #111;
+}
+
+#app-content {
+  background: #222;
+  border-radius: 8px;
+  padding: 2rem;
+  box-shadow: 0 2px 8px #000a;
+}
+
+.broken-badge {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(255, 193, 7, 0.9);
+  color: #000;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  z-index: 10;
+}
+
+.btn-warning {
+  background: #ffc107;
+  border: none;
+  color: #000;
+  font-family: 'Press Start 2P', monospace;
+}
+
+.btn-warning:hover {
+  background: #e0a800;
+}
+
+.legend {
+  border: 2px solid #444;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.legend-icon {
+  font-size: 1.2rem;
+}
+
+.tooltip-custom {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.7rem;
+}


### PR DESCRIPTION
I wanted an easier way to see all the apps available. 

# App Viewer Frontend

## Features
- 🔍 **Search functionality** for all apps
- 📱 **Responsive card layout** with dark pixel theme
- 📄 **README rendering** with embedded image support  
- ⚠️ **Broken app indicators** (reads from broken_apps.txt)
- 🎨 **Bootstrap + Press Start 2P** font styling
- 📊 **App descriptions** extracted from README files
- 🔗 **GitHub issue reporting** for broken apps
- 🚀 **GitHub Actions** workflow for auto-deployment

## Files Added
- `app-viewer/` - Complete static web application
- `.github/workflows/deploy-pages.yml` - CI/CD pipeline
- Auto-generates `apps.json` from repository contents


## Screenshots
Full Page Viewer
<img width="1334" height="878" alt="image" src="https://github.com/user-attachments/assets/f2c899eb-7e81-4725-818e-ea1b769c9025" />

Broken App
<img width="1334" height="878" alt="image" src="https://github.com/user-attachments/assets/4720426c-4fb9-4284-81c8-70069418129b" />

Full App Details (with Deep link)
<img width="1334" height="878" alt="image" src="https://github.com/user-attachments/assets/82e07367-eb6c-47a0-80a0-779fdb120508" />

Report Broken App
<img width="932" height="110" alt="image" src="https://github.com/user-attachments/assets/ed3dbd8a-c8c2-432c-9fce-9942eb705ede" />
