### PR TITLE
Fix Product Hunt app

### DIFF
--- a/apps/producthunt/manifest.yaml
+++ b/apps/producthunt/manifest.yaml
@@ -2,6 +2,6 @@
 id: product-hunt
 name: Product Hunt
 summary: Product Hunt top products
-desc: View the daily top tech products from Product Hunt.
+desc: View the daily top tech products from Product Hunt. Generate your Developer Token at https://www.producthunt.com/v2/oauth/applications.
 author: Daniel Sitnik
 recommended_interval: 5


### PR DESCRIPTION
Fixing the PH app.
It now requires a Developer Token in the schema and uses the official GraphQL API.

Developer tokens are free and can be generated by any user at https://www.producthunt.com/v2/oauth/applications.