### PR TITLE
chore(fireflies): do not show full animation

### DIFF
--- a/apps/fireflies/fireflies.star
+++ b/apps/fireflies/fireflies.star
@@ -398,7 +398,6 @@ def render_clock(timezone):
 def render_animation(frames):
     return render.Root(
         delay = DELAY,
-        show_full_animation = True,
         child = render.Animation(children = frames),
     )
 


### PR DESCRIPTION
The fireflies app shows the full animation, but does not have any scrolling text or anything, so this is not necessary.