### PR TITLE
Add Fahrenheit support, radon monitoring, customizable thresholds, and enhanced display options

### DIFF
--- a/apps/airthings/airthings.star
+++ b/apps/airthings/airthings.star
@@ -44,6 +44,7 @@ def main(config):
     onlyDisplayNotNormal = config.bool("onlyDisplayNotNormal")
     enableScrolling = config.bool("enableScrolling", True)
     scrollSpeed = int(config.get("scrollSpeed", "100"))
+    scrollDuration = int(config.get("scrollDuration") or "120")
     fontSize = config.get("fontSize", "medium")
     tempUnit = config.get("tempUnit", "celsius")
 
@@ -202,10 +203,10 @@ def main(config):
         radon = "n/a"
     else:
         # Round radon to 1 decimal place
-        radon = int(radon * 10) / 10
+        radon = int(radon * 10 + 0.5) / 10
     
     # Round temperature to 1 decimal place
-    temp = int(temp * 10) / 10
+    temp = int(temp * 10 + 0.5) / 10
     
     # Set font based on fontSize option
     if fontSize == "small":
@@ -260,7 +261,7 @@ def main(config):
                 ),
             ),
             delay = scrollSpeed,
-            max_age = 120,
+            max_age = scrollDuration,
         )
     else:
         return render.Root(
@@ -337,6 +338,7 @@ def get_schema():
                 name = "AirThings API Client Secret",
                 desc = "REQUIRED: API secret from https://dashboard.airthings.com/integrations/api-integration",
                 icon = "gear",
+                secret = True,
             ),
             schema.Text(
                 id = "clientId",
@@ -399,6 +401,13 @@ def get_schema():
                         value = "20",
                     ),
                 ],
+            ),
+            schema.Text(
+                id = "scrollDuration",
+                name = "Scroll Duration (seconds)",
+                desc = "Maximum time in seconds for one complete scroll cycle (default: 120)",
+                icon = "clock",
+                default = "120",
             ),
             schema.Dropdown(
                 id = "fontSize",


### PR DESCRIPTION

New Features:

Temperature unit selection: Toggle between Celsius and Fahrenheit display with appropriate threshold conversions
Radon monitoring: Display short-term radon levels (radonShortTermAvg) with automatic Bq/m³ to pCi/L conversion and EPA-based thresholds
Vertical scrolling: Marquee animation to display all sensor readings with 2-second initial pause
Customizable thresholds: User-configurable warning/alert levels for all sensors (CO2, PM2.5, temperature, VOC, humidity, radon)
Display customization:

Three font sizes (Small, Medium, Large)
Five scroll speeds (Very Slow to Very Fast)
Toggle to enable/disable scrolling
Individual sensor visibility controls



Display Changes:

Reordered sensors: Temperature, Humidity, CO2, PM2.5, VOC, Radon (groups comfort and air quality metrics)
Temperature now shown by default (previously hidden)
Scroll speed defaults to "Very Slow" for better readability

Threshold Configuration:
All sensors now support custom thresholds with sensible defaults:

CO2: Yellow 800 ppm, Red 1000 ppm
PM2.5: Yellow 10 µg/m³, Red 25 µg/m³
Temperature (°F): Yellow 72°F, Red 77°F
Temperature (°C): Yellow 22°C, Red 25°C
VOC: Yellow 250 ppb, Red 2000 ppb
Humidity: Low 30%, Yellow 60%, Red 70%
Radon: Yellow 2.7 pCi/L, Red 4.0 pCi/L (EPA action level)

Backward Compatibility:

All defaults preserve original app behavior (Celsius, original thresholds)
Graceful handling of missing radon data (displays "n/a")
No breaking changes for existing users
All new features are opt-in enhancements

Technical Details:

Temperature conversion: (C × 9/5) + 32 = F
Radon conversion: Bq/m³ × 0.027 = pCi/L
Values rounded to 1 decimal place
Marquee with configurable delay and max_age

Code Impact:

Added ~90 lines (~37% increase from 240 to 330 lines)
No changes to authentication, caching, or API integration
Additive enhancements only