### PR TITLE
fix(teslamate): convert charger power to a float

### DIFF
--- a/apps/teslamate/teslamate.star
+++ b/apps/teslamate/teslamate.star
@@ -266,7 +266,7 @@ def main(config):
     plugged_states = ["on", "true", "1", "yes", "plugged in", "plugged", "connected"]
     is_plugged = str(plugged_in).lower() in plugged_states
 
-    if charger_power > 0:
+    if float(charger_power) > 0:
         image = BOLT_ANIMATED
     elif battery_val >= limit_val and is_plugged:
         image = BOLT_GREEN


### PR DESCRIPTION
The sample data causes an error
```
Error: error rendering: error running script: Traceback (most recent call last):
  teslamate.star:269:22: in main
Error: string > int not implemented
```
This PR converts `charger_power` to an int to fix this