### PR TITLE
Fix bug that caused a 500

### DIFF
--- a/apps/spotify/spotify.star
+++ b/apps/spotify/spotify.star
@@ -1112,14 +1112,10 @@ def render_idle(config, recent_state = None):
     # Show recent track if available
     if recent_state:
         # Render with dimmed colors to indicate not current
-        # Create a simple wrapper that returns dimmed colors
         dimmed_config = {
-            "display_mode": config.get("display_mode", MODE_FULL),
             "scroll_speed": config.get("scroll_speed", "50"),
-            "show_time": config.get("show_time", "true"),
             "track_color": LIGHT_GRAY,
             "artist_color": DARK_GRAY,
-            "progress_color": DARK_GRAY,
         }
 
         # Add "Last played" indicator somehow


### PR DESCRIPTION
This bug would only trigger when both of these conditions are true:

Nothing is currently playing (no active track, not even paused)
"Show Recently Played" is enabled in the app settings

In that scenario, the app tries to show your last played track with dimmed colors. The dict(config) call would crash before it could render anything, causing the 500.
If "Show Recently Played" is disabled (the default), this code path is never hit - the app just shows the idle "Spotify / Not Playing" screen instead, which doesn't need to copy the config.

Also re-added the full readme URL that got removed due to my bad management of files.