### PR TITLE
Refactor apps to use HTTP cache

### DIFF
--- a/apps/dancewave/dance-wave.star
+++ b/apps/dancewave/dance-wave.star
@@ -2,8 +2,6 @@
 Dance Wave - A Tidbyt app showing the currently playing song from Dance Wave Online Radio
 """
 
-load("cache.star", "cache")
-load("encoding/json.star", "json")
 load("http.star", "http")
 load("images/dw_logo.gif", DW_LOGO_ASSET = "file")
 load("render.star", "render")
@@ -114,12 +112,7 @@ def fetch_current_track():
         "Referer": "https://dancewave.online/tracklist/",
     }
 
-    # Cache the API response for 30 seconds
-    cached = cache.get("current_track")
-    if cached != None:
-        return json.decode(cached)
-
-    resp = http.get(url, headers = headers)
+    resp = http.get(url, headers = headers, ttl_seconds = CACHE_TTL_SECONDS)
 
     if resp.status_code == 200:
         data = resp.json()
@@ -132,7 +125,6 @@ def fetch_current_track():
                 "artist": current.get("artist", "Unknown Artist"),
                 "title": current.get("title", "Unknown Title"),
             }
-            cache.set("current_track", json.encode(track_data), ttl_seconds = CACHE_TTL_SECONDS)
             return track_data
         else:
             print("No playlist data found")

--- a/apps/justfortoday/just_for_today.star
+++ b/apps/justfortoday/just_for_today.star
@@ -5,7 +5,6 @@ Description: Show today's N.A. "Just for Today".
 Author: elliotstoner
 """
 
-load("cache.star", "cache")
 load("http.star", "http")
 load("images/jft_header.png", JFT_HEADER_ASSET = "file")
 load("render.star", "render")
@@ -25,22 +24,21 @@ def getCurrentDate(config):
 
 def getJftText(config):
     curr_date = getCurrentDate(config)
-    jft_text = cache.get(curr_date)
-    if jft_text == None:
-        root_url = config.get("JFT_DATA_ROOT_URL")
-        if root_url == None:
-            return DEFAULT_TEXT
-        req_url = "%s/%s/%s%s" % (
-            root_url,
-            JFT_SOURCE,
-            curr_date,
-            FILE_TYPE,
-        )
-        request = http.get(req_url)
-        if (request.status_code != 200):
-            return DEFAULT_TEXT
-        jft_text = request.body()
-        cache.set(curr_date, jft_text, ttl_seconds = 86400)
+
+    root_url = config.get("JFT_DATA_ROOT_URL")
+    if root_url == None:
+        return DEFAULT_TEXT
+    req_url = "%s/%s/%s%s" % (
+        root_url,
+        JFT_SOURCE,
+        curr_date,
+        FILE_TYPE,
+    )
+    request = http.get(req_url, ttl_seconds = 86400)
+    if (request.status_code != 200):
+        return DEFAULT_TEXT
+    jft_text = request.body()
+
     return jft_text
 
 def get_schema():

--- a/apps/news/news.star
+++ b/apps/news/news.star
@@ -5,7 +5,6 @@ Description: Select an RSS feed and receive the latest headlines in return.
 Author: JeffLac (Recreation of Tidbyt Original)
 """
 
-load("cache.star", "cache")
 load("http.star", "http")
 load("images/bbc.png", BBC_LOGO_ASSET = "file")
 load("images/la_times_logo.png", LA_TIMES_LOGO_ASSET = "file")
@@ -205,20 +204,6 @@ def main(config):
 def get_headlines(feed_url):
     """Fetch and parse headlines from an RSS feed using xpath."""
 
-    # Try to get cached data
-    cached = cache.get("headlines_%s" % feed_url)
-    if cached != None:
-        cached_data = []
-
-        # Parse the cached data
-        items = cached.split("||||")
-        for i in range(0, len(items) - 1, 2):
-            cached_data.append({
-                "title": items[i],
-                "description": items[i + 1],
-            })
-        return cached_data
-
     # Fetch the RSS feed
     resp = http.get(feed_url, ttl_seconds = CACHE_TTL)
     if resp.status_code != 200:
@@ -248,15 +233,6 @@ def get_headlines(feed_url):
                 "title": title,
                 "description": description,
             })
-
-    # Cache the results as pipe-delimited string
-    if len(items) > 0:
-        cache_parts = []
-        for item in items:
-            cache_parts.append(item["title"])
-            cache_parts.append(item["description"])
-        cache_content = "||||".join(cache_parts)
-        cache.set("headlines_%s" % feed_url, cache_content, ttl_seconds = CACHE_TTL)
 
     return items
 

--- a/apps/shouldideploytoday/shouldideploy.star
+++ b/apps/shouldideploytoday/shouldideploy.star
@@ -1,4 +1,3 @@
-load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("render.star", "render")
@@ -47,38 +46,29 @@ def main(config):
 
     image_to_use = None
     color_to_use = None
-    cached_response = cache.get(api_url_w_timezone)
-    if not cached_response:
-        resp = http.get(api_url_w_timezone)
-        if resp.status_code != 200:
-            if "does not exist" in resp.json()["error"]["message"]:
-                image_to_use = DESIGNS["error"]["url"]
-                color_to_use = DESIGNS["error"]["color"]
-                resp = {}
-                resp["shouldideploy"] = False
-                resp["message"] = "Timezone '%s' is not supported" % timezone
-            else:
-                fail(
-                    "shouldideploy.today request failed with status %d",
-                    resp.status_code,
-                )
+
+    resp = http.get(api_url_w_timezone, ttl_seconds = 120)
+    if resp.status_code != 200:
+        if "does not exist" in resp.json()["error"]["message"]:
+            image_to_use = DESIGNS["error"]["url"]
+            color_to_use = DESIGNS["error"]["color"]
+            resp = {}
+            resp["shouldideploy"] = False
+            resp["message"] = "Timezone '%s' is not supported" % timezone
         else:
-            resp = resp.json()
-            cache.set(api_url_w_timezone, json.encode(resp), ttl_seconds = 120)
+            fail(
+                "shouldideploy.today request failed with status %d",
+                resp.status_code,
+            )
     else:
-        resp = json.decode(cached_response)
+        resp = resp.json()
 
     shouldideploy = resp["shouldideploy"]
     message = resp["message"]
     image_to_use = image_to_use or DESIGNS[design][shouldideploy]["url"]
     color_to_use = color_to_use or DESIGNS[design][shouldideploy]["color"]
 
-    cached_image = cache.get(image_to_use)
-    if cached_image:
-        image = cached_image
-    else:
-        image = http.get(image_to_use).body()
-        cache.set(image_to_use, image, ttl_seconds = 86400)
+    image = http.get(image_to_use, ttl_seconds = 86400).body()
 
     return render.Root(
         child = render.Box(


### PR DESCRIPTION
Migrate several apps from manual cache.get/cache.set to using the ttl_seconds parameter in http.get. This simplifies the code by removing the explicit dependency on the cache module and delegating cache management to the HTTP client.

Apps updated:
- Dance Wave
- Just For Today
- MTA Bus
- News
- Should I Deploy Today
- The Tracker