### PR TITLE
[hassmedia] conditionally add HA host to image url

### DIFF
--- a/apps/hassmedia/hassmedia.star
+++ b/apps/hassmedia/hassmedia.star
@@ -51,7 +51,11 @@ def get_entity_data(config):
     return (data, None) if data else ({}, None)
 
 def get_image(url, config):
-    url = config.str("ha_instance") + url
+    if not url:
+        return None, None
+    elif not url.startswith("http"):
+        url = config.str("ha_instance") + url
+
     headers = {
         "Authorization": "Bearer " + config.str("ha_token"),
         "Content-Type": "application/json",


### PR DESCRIPTION
I've started using a different media entity in Home Assistant which supplies a full URI for the album art. Currently the widget always prefixes the HA instance URL, which means an invalid URL when the data already returns a full URI.