### PR TITLE
Bill board fixes

### DIFF
--- a/apps/billboardtop10/billboardtop10.star
+++ b/apps/billboardtop10/billboardtop10.star
@@ -19,8 +19,7 @@ BILLBOARD_SAMPLE_DATA = """{"info": {"category": "Billboard", "chart": "HOT 100"
 
 DEFAULT_COLORS = ["#FFF", "#f41b1c", "#ffe400", "#00b5f8"]
 
-#cache Time 3 Days x 24 hours x 60 minutes x 60 seconds = 259200 seconds
-CACHE_TTL_SECONDS = 259200
+CACHE_TTL_SECONDS = 3 * 24 * 60 * 60  # 3 days in seconds
 
 list_options = [
     schema.Option(


### PR DESCRIPTION
This works fine running on my Mac using pixlet. However, it did last time as well, but failed when it got to the Tronbyt Manager.

I followed the pattern of other working apps to hopefully avoid the errors on reading images locally. 

This will also use the HTTP cache, and it adds a check to see if the api provided data or gave me a 'you're over your limit' message. I tested so much, I got shut out and had never handled that error before. 

Any advice to test this on a Tronbyt would be nice. When I got my changes to the Raspberry PI, Tronbyt manager was still using the original from the Tronbyt/Apps repository, and not mine.