### PR TITLE
Spotify: Add config toggle for hiding when paused

### DIFF
--- a/apps/spotify/spotify.star
+++ b/apps/spotify/spotify.star
@@ -3,7 +3,7 @@ Spotify Now Playing - Ultimate Edition for Tronbyt/Tidbyt
 =========================================================
 
 Author: gshepperd
-Version: 2.0.0
+Version: 2.1.0
 
 ================================================================================
                             INSTALLATION INSTRUCTIONS
@@ -1255,11 +1255,14 @@ def main(config):
         return render_error("API Error", fetch_error)
 
     if state:
-        if is_current or state["is_playing"]:
-            # Currently playing or paused
+        show_paused = config.bool("show_paused_tracks", True)
+        should_display = state["is_playing"] or (is_current and show_paused)
+
+        if should_display:
+            # Currently playing or paused (if enabled)
             return render_playback(state, config)
         else:
-            # Showing recently played
+            # Showing recently played or paused track (when disabled)
             return render_idle(config, recent_state = state)
     else:
         # Nothing to show
@@ -1334,6 +1337,13 @@ def get_schema():
                 desc = "When nothing playing, show last played track",
                 icon = "clockRotateLeft",
                 default = False,
+            ),
+            schema.Toggle(
+                id = "show_paused_tracks",
+                name = "Show Paused Tracks",
+                desc = "Display tracks when paused (if disabled, only shows actively playing tracks)",
+                icon = "pause",
+                default = True,
             ),
             schema.Toggle(
                 id = "show_when_idle",


### PR DESCRIPTION
* Adds a config toggle to treat paused playback as idle
* When show_when_idle is disabled, return an empty list so the app is treated as "inactive" and skipped in the rotation, rather than displaying a blank screen.