### PR TITLE
fix(menscricket): handle None values in `_safe_float`

### DIFF
--- a/apps/menscricket/mens_cricket.star
+++ b/apps/menscricket/mens_cricket.star
@@ -933,7 +933,8 @@ def _safe_float(val):
         if val == "$undefined":
             return 0.0
         return float(val)
-    return float(val)
+
+    return float(val) if val else 0.0
 
 def main(config):
     tz = time.tz()


### PR DESCRIPTION
In cases where an innings target did not yet exist, the "target" key would still exist inside of the scorecard, but with a None value, meaning that it would not properly default to 0 before being passed to `_safe_float`, causing a crash.

- Added a check for None values into `_safe_float` so that it safely defaults to 0.0 if passed a None value.