### PR TITLE
fix(ha_columns): use `humanize.float` to fix conversion error

### DIFF
--- a/apps/ha_columns/ha_columns.star
+++ b/apps/ha_columns/ha_columns.star
@@ -34,12 +34,13 @@ def _get_default_fonts(column_count, scale):
     return label_font, value_font
 
 def _format_sensor_value(value, decimals):
-    if decimals == 0:
-        return humanize.float("0.", value)
-    elif decimals == 1:
-        return humanize.float("0.0", value)
-    else:
-        return humanize.float("0.00", value)
+    formats = {
+        0: "0.",
+        1: "0.0",
+        2: "0.00",
+    }
+    fmt = formats.get(decimals, "0.00")
+    return humanize.float(fmt, value)
 
 def main(config):
     scale = 2 if canvas.is2x() else 1


### PR DESCRIPTION
Changes unsupported format specifiers to `humanize.float(...)` to fix unknown conversion errors.

Fixes #284