### PR TITLE
Improve performance of Meteoschweiz 3-hour forecast

### DIFF
--- a/apps/meteoschweiz/meteoschweiz.star
+++ b/apps/meteoschweiz/meteoschweiz.star
@@ -565,6 +565,8 @@ def fetch_csv_data(url, ttl_seconds = 21600):
 
     Returns:
         A dictionary mapping point_id to a dictionary of {timestamp: value} pairs.
+    """
+
     # Check cache first
     cache_key = "meteoschweiz_csv_{}".format(url)
     cached = cache.get(cache_key)


### PR DESCRIPTION
Unfortunately, the files for the 3-hour forecast are quite large. This results sometimes in a render timeout. I optimized the code a bit and added more caching to also cache the already downloaded CSV-Files. This should help to continue and render the app in a second loop, in case the first one runs into a timeout.