### PR TITLE
fix(denser_bart): properly filter station

### DIFF
--- a/apps/denser_bart/denser_bart.star
+++ b/apps/denser_bart/denser_bart.star
@@ -25,7 +25,7 @@ def main(config):
         abbr = DEFAULT_ABBR
     elif abbr.startswith("{"):
         # schema.Typeahead returns a JSON string with value field
-        abbr = json.decode(abbr).get("value", DEFAULT_ABBR)
+        abbr = json.decode(abbr).get("value", abbr)
 
     viz = config.bool("long_abbr")
 


### PR DESCRIPTION
When using the typeahead to filter for a station, the app config was being set to something like this:

```json
{
  "abbr": {
    "display": "Embarcadero",
    "text": "Embarcadero",
    "value": "EMBR"
  },
  "long_abbr": "false"
}
```

However, the app was expecting to only get the `value` field. This change parses the `abbr` field as json and properly filters for `abbr.value`. 

Before, the app showed "No Data" when a station was selected. Now, we properly display the times for the selected station.