### PR TITLE
Adding "foggy" for weather codes in the 700 range

### DIFF
--- a/apps/ogclock/og_clock.star
+++ b/apps/ogclock/og_clock.star
@@ -361,6 +361,8 @@ def main(config):
             icon_ref = "snowy2.png"
         elif icon_num == 731:
             icon_ref = "windy.png"
+        elif icon_num >= 701 and icon_num < 800:
+            icon_ref = "foggy.png"
         elif icon_num == 800 and "n" in icon_code:
             icon_ref = "moony.png"
         elif icon_num >= 801 and icon_num <= 804 and "n" in icon_code:
@@ -394,6 +396,8 @@ def main(config):
             icon_ref = "snowy2.png"
         elif icon_num == 731:
             icon_ref = "windy.png"
+        elif icon_num >= 701 and icon_num < 800:
+            icon_ref = "foggy.png"
         elif icon_num == 800 and "n" in icon_code:
             icon_ref = "moony.png"
         elif icon_num >= 801 and icon_num <= 804 and "n" in icon_code:


### PR DESCRIPTION
OGClock doesn't show an image when the API returns "Foggy" 

Foggy's weather code is, as per https://openweathermap.org/weather-conditions , 741

The entire range of 700's is basically missing. This PR adds the missing codes.

731, "dust", is special cased in the original code as  "Windy". I left this as is even though the open weather docs specifies this should be the "foggy" graphic. 