### PR TITLE
Remove Gartner App

### DIFF
--- a/apps/gartnernews/manifest.yaml
+++ b/apps/gartnernews/manifest.yaml
@@ -7,3 +7,4 @@ author: Robert Ison
 fileName: gartner_news.star
 packageName: gartnernews
 recommendedInterval: 5
+broken: true


### PR DESCRIPTION
Mark as Broken since https://www.gartner.com/en/newsroom/rss source now requires a CAPTCHA