### PR TITLE
Fix DEF_CON_URL that was recently updated

### DIFF
--- a/apps/defcon/defcon.star
+++ b/apps/defcon/defcon.star
@@ -9,7 +9,7 @@ load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 
-DEF_CON_URL = "https://www.defconlevel.com/current-level.php"
+DEF_CON_URL = "https://www.defconlevel.com/current-level"
 CACHE_TTL_SECONDS = 259200
 FONT = "6x13"
 DEF_CON_COLORS = ["#fff", "#ff0000", "#ffff00", "#00ff00", "#0000ff"]


### PR DESCRIPTION
They recently changed the URL from https://www.defconlevel.com/current-level.php to simply https://www.defconlevel.com/current-level