### PR TITLE
DuoLingo: Add token

### DIFF
--- a/apps/duolingo/duolingo.star
+++ b/apps/duolingo/duolingo.star
@@ -179,6 +179,7 @@ def get_schema():
                 desc = "Find 'jwt_token' in your browser cookies for duolingo.com and enter it here. This is required to retrieve your XP data. The token is valid for 30 days and will be cached, but you will need to update it here each time it expires.",
                 icon = "key",
                 default = "",
+                secret = True,
             ),
             schema.Dropdown(
                 id = "xp_target",
@@ -411,7 +412,6 @@ def main(config):
             timezone,
         )
 
-        print(DUOLINGO_XP_QUERY_URL)
         xpsummary_query = http.get(DUOLINGO_XP_QUERY_URL, headers = headers, ttl_seconds = 900)
         if xpsummary_query.status_code != 200:
             print("XP summary query failed with status %d", xpsummary_query.status_code)


### PR DESCRIPTION
DuoLingo will fail if you aren't logged in. Now you can find and add your jwt token in the settings, and it will at least run for 30 days now.