### PR TITLE
[WoWCharacterStats] Refactor raid progress calculations for Midnight S1

### DIFF
--- a/apps/wowcharacterstats/wowcharacterstats.star
+++ b/apps/wowcharacterstats/wowcharacterstats.star
@@ -375,16 +375,15 @@ def get_raid_progress(progress):
                 for instance in expansion["instances"]:
                     if instance["modes"]:
                         mode = instance["modes"][-1]
-                        if RAID_LEVELS[mode["difficulty"]["name"]] > raid_level:
-                            raid_level = RAID_LEVELS[mode["difficulty"]["name"]]
-                            completed = mode["progress"]["completed_count"]
-                            total += mode["progress"]["total_count"]
+                        total += mode["progress"]["total_count"]
+                        current_difficulty_level = RAID_LEVELS[mode["difficulty"]["name"]]
+
+                        if current_difficulty_level > raid_level:
+                            raid_level = current_difficulty_level
                             difficulty = mode["difficulty"]["name"]
-                        elif RAID_LEVELS[mode["difficulty"]["name"]] == raid_level:
+                            completed = mode["progress"]["completed_count"]
+                        elif current_difficulty_level == raid_level:
                             completed += mode["progress"]["completed_count"]
-                            total += mode["progress"]["total_count"]
-                        else:
-                            total += mode["progress"]["total_count"]
 
     if difficulty != "":
         status = "%d/%d %s" % (completed, total, difficulty[:1])


### PR DESCRIPTION
Unlike recent expansion seasons, Midnight Season 1 will have multiple raids. This refactor will iterate through all the "instances" in the "Current Season" expansion and count all completed bosses / total bosses for the highest raid level completed and use that for raid progress.

Example: 
- If a player has defeated 1/2 bosses in Raid1, 1/1 bosses in Raid2, and 3/6 bosses in Raid3, all at heroic level, their overall raid progress for the season will be `5/9 H`.
- If a player has defeated 2/2 bosses in Raid1 and 1/1 bosses in Raid2 on heroic level, but and 3/6 bosses in Raid3 on mythic level, their overall raid progress for the season will be `3/9 M`.

This refactor also utilizes the "Current Season" expansion that is available in the raid progress API response, which updates automatically with each season. This means we will no longer need to update the `CURRENT_EXPANSION` and `CURRENT_INSTANCE` variable each season.