### PR TITLE
fix(weather): fix three-day forecast image scale

### DIFF
--- a/apps/weather/weather.star
+++ b/apps/weather/weather.star
@@ -747,8 +747,8 @@ def render_weather(daily_data, scale = 1, icon_scale = 1):
                 # Weather icon
                 render.Image(
                     src = get_weather_icon(day["weather"], icon_scale),
-                    width = 12 * scale,
-                    height = 12 * scale,
+                    width = 13 * scale,
+                    height = 13 * scale,
                 ),
                 # Day abbreviation
                 render.Text(


### PR DESCRIPTION
The three-day forecast images are 13x13, but the app renders them at 12x12. This results in weird scaling artifacts.

| Scale | Before | After |
|-|-|-|
| 1x | <img width="256" height="128" alt="before-1x" src="https://github.com/user-attachments/assets/ffde6868-1ad4-47c2-b173-299c778156d6" /> | <img width="256" height="128" alt="after-1x" src="https://github.com/user-attachments/assets/46d05737-50ba-4a0a-8166-555d30b5a129" /> |
| 2x | <img width="256" height="128" alt="before-2x" src="https://github.com/user-attachments/assets/274c8af9-5d14-4964-9729-e6fea87c2a0d" /> | <img width="256" height="128" alt="after-2x" src="https://github.com/user-attachments/assets/f1d599aa-cc64-4059-a4ae-becdbd18eecf" />


