### PR TITLE
fix(surflive): update search API URL

### DIFF
--- a/apps/surfforecast/surf_forecast.star
+++ b/apps/surfforecast/surf_forecast.star
@@ -33,7 +33,7 @@ ICON_NE = ICON_NE_ASSET.readall()
 SURFLINE_RATING_URL = "https://services.surfline.com/kbyg/spots/forecasts/rating?spotId={spot_id}&days=1&intervalHours=1&correctedWind=False"
 SURFLINE_WAVE_URL = "https://services.surfline.com/kbyg/spots/forecasts/wave?spotId={spot_id}&days=1&intervalHours=1"
 SURFLINE_WIND_URL = "https://services.surfline.com/kbyg/spots/forecasts/wind?spotId={spot_id}&days=1&intervalHours=1&corrected=False"
-SURFLINE_QUERY_URL = "https://services.surfline.com/onboarding/spots?query={query}&limit=5&offset=0&camsOnly=false"
+SURFLINE_QUERY_URL = "https://services.surfline.com/search/site?q={query}&querySize=5"
 
 COLOR_BY_SURFLINE_RATING = {
     "FLAT": "#A2ACB9",  #gray
@@ -500,8 +500,9 @@ def transparent(color, p):
     return res
 
 def search_handler(text):
-    response = get(SURFLINE_QUERY_URL.format(query = text))
-    return [schema.Option(display = s["name"], value = s["_id"]) for s in response["spots"]]
+    response = get(SURFLINE_QUERY_URL.format(query = text), SHORT_CACHE_TTL)
+    hits = response[0].get("hits", {}).get("hits", []) if response else []
+    return [schema.Option(display = h["_source"]["name"], value = h["_id"]) for h in hits]
 
 def get_schema():
     min_height_options = [

--- a/apps/surflive/surflive.star
+++ b/apps/surflive/surflive.star
@@ -22,7 +22,7 @@ WAVE_ICON_WIDTH = 10
 
 # FORECAST API
 SURFLINE_FORECASTS_URL = "https://services.surfline.com/kbyg/spots/forecasts"
-SEARCH_URL = "https://services.surfline.com/onboarding/spots?query={query}&limit=12&offset=0&camsOnly=false"
+SEARCH_URL = "https://services.surfline.com/search/site?q={query}&querySize=12"
 
 # 15 minutes
 ENABLE_CACHE = True
@@ -282,7 +282,9 @@ def search_spots(query):
     if r.status_code != 200:
         fail("Error fetching spots, query={query}".format(query = query))
 
-    return r.json()["spots"]
+    res_json = r.json()
+    hits = res_json[0].get("hits", {}).get("hits", []) if res_json else []
+    return [{"_id": h["_id"], "name": h["_source"]["name"]} for h in hits]
 
 def search_handler(query):
     spots = search_spots(query)


### PR DESCRIPTION
The currently used Surfline search endpoint gives a 502, so this PR updates to the new search endpoint. `surfforecast.star` doesn't actually use this handler anymore, but it will work if that's ever reverted.