### PR TITLE
Add Wide 3 + Wide 4 (2x) display styles to Mens & Womens Soccer

### DIFF
--- a/apps/soccermens/manifest.yaml
+++ b/apps/soccermens/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - real-time
   - soccer
 published: '2022-11-17T18:58:26Z'
-updated: '2026-06-17T20:09:49Z'
+updated: '2026-06-17T20:59:26Z'

--- a/apps/soccermens/manifest.yaml
+++ b/apps/soccermens/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - real-time
   - soccer
 published: '2022-11-17T18:58:26Z'
-updated: '2025-12-02T19:30:22Z'
+updated: '2026-06-17T20:09:49Z'

--- a/apps/soccermens/manifest.yaml
+++ b/apps/soccermens/manifest.yaml
@@ -7,6 +7,7 @@ author: jvivona
 fileName: soccermens.star
 packageName: soccermens
 recommendedInterval: 5
+supports2x: true
 category: sports
 tags:
   - real-time

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -907,11 +907,11 @@ def get_comp_label(scoreboard_url, leagueAbbr):
     # (leagues[0].abbreviation, e.g. "FIFA World Cup") for the header. Works for
     # every league/tournament the app offers; falls back to the short league code.
     data = json.decode(get_cachable_data(scoreboard_url))
-    leagues = data.get("leagues", [])
+    leagues = data.get("leagues") or []
     if len(leagues) > 0:
-        abbr = leagues[0].get("abbreviation", "")
-        if abbr != "":
-            return abbr
+        abbr = leagues[0].get("abbreviation")
+        if abbr:
+            return str(abbr)
     return leagueAbbr
 
 def parse_game_wide(s, config, timezone):
@@ -921,8 +921,8 @@ def parse_game_wide(s, config, timezone):
         return None
 
     state = s["status"]["type"]["state"]
-    type_name = s["status"]["type"].get("name", "")
-    short_detail = s["status"]["type"].get("shortDetail", "")
+    type_name = s["status"]["type"].get("name") or ""
+    short_detail = s["status"]["type"].get("shortDetail") or ""
 
     # local date for day grouping + header (short, no weekday)
     dt = time.parse_time(s["date"], format = "2006-01-02T15:04Z").in_location(timezone)
@@ -938,8 +938,8 @@ def parse_game_wide(s, config, timezone):
     # penalty shootout: scores present while pens are live AND after (FINAL_PEN).
     # The regulation score stays in the score slot; the tally goes in the status
     # ("PK 4-2" live / "FT 4-2" final) since 0(4)-0(2) won't fit the narrow center.
-    hp = competitors[0].get("shootoutScore", "0")
-    ap = competitors[1].get("shootoutScore", "0")
+    hp = competitors[0].get("shootoutScore") or "0"
+    ap = competitors[1].get("shootoutScore") or "0"
     pen_final = type_name == "STATUS_FINAL_PEN"
     pen_live = state == "in" and (hp != "0" or ap != "0")
 
@@ -1016,18 +1016,20 @@ def parse_game_wide(s, config, timezone):
     )
 
 def wide_side(competitor):
-    team = competitor["team"]
-    name = team.get("name", "")
-    code = team.get("abbreviation", name[0:3].upper() if name != "" else "?")
-    logo_url = team.get("logo", "") or MISSING_LOGO
-    score = competitor.get("score", "")
+    team = competitor.get("team") or {}
+    name = team.get("name") or ""
+    code = team.get("abbreviation") or (name[0:3].upper() if name else "?")
+    logo_url = team.get("logo") or MISSING_LOGO
+    score_val = competitor.get("score")
+    score = str(score_val) if score_val != None else ""
     record = ""
-    recs = competitor.get("records", None)
-    if recs != None and len(recs) > 0:
-        record = recs[0].get("summary", "")
+    recs = competitor.get("records")
+    if recs and len(recs) > 0:
+        summary = recs[0].get("summary")
+        record = str(summary) if summary != None else ""
     return dict(
         code = code[:3],
-        color = wide_team_color(team.get("color", "")),
+        color = wide_team_color(team.get("color")),
         logo = get_logoType(logo_url),
         score = score,
         record = record,
@@ -1060,6 +1062,8 @@ def wide_team_color(hexcolor):
     # Returned with an alpha suffix so the band softens against the black panel
     # (same idea as the legacy "colors" style's 77 alpha), keeping white/yellow
     # text readable.
+    if not hexcolor:
+        return W_STEEL + W_TEAM_ALPHA
     h = hexcolor.replace("#", "")
     if len(h) != 6:
         return W_STEEL + W_TEAM_ALPHA

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -56,7 +56,7 @@ SHORTENED_WORDS = """
 """
 
 # ============================================================================
-# Wide 2x layouts (display options #5 "Wide 3" and #6 "Wide 6")
+# Wide 2x layouts (display options "Wide 3" and "Wide 4")
 # Designed for the native 128x64 canvas. See design handoff README.
 # All sizes are in LED units (the real grid), not the mock's px.
 # ============================================================================
@@ -87,8 +87,8 @@ W_FONT_CODE = "tb-8"
 W_FONT_REC = "tb-8"
 W_FONT_SCORE = "6x10"  # hero score / kickoff in Wide 3 (was 6x13 — toned down)
 W3_STATUS_FONT = "CG-pixel-3x5-mono"  # Wide 3 status line (5 LED, fits under 6x13)
-W_FONT_STATUS = "tom-thumb"  # Wide 6 status chips / records
-W_FONT_CELL = "tb-8"  # code + score in Wide 6 cells
+W_FONT_STATUS = "tom-thumb"  # Wide 3/4 status chips / records
+W_FONT_CELL = "tb-8"  # code + score in Wide 4 cells
 
 # Geometry (LED units)
 W_W = 128
@@ -100,7 +100,7 @@ W_HEADER_H = 8  # 7 bg + 1 rule (all-caps day header has no descenders)
 W3_CENTER_W = 26
 W3_ROW_H = 18  # 3 rows * 18 + 2 * 1 divider == 56 body, exact
 W3_FLAG = 16  # flag/crest in Wide 3 zone
-W6_FLAG = 9  # flag/crest in Wide 6 cell line
+W4_FLAG = 9  # flag/crest in Wide 4 cell line
 
 def main(config):
     LEAGUE_ABBR = json.decode(http.get(url = ABBR_URL, ttl_seconds = COMPS_TTL).body())
@@ -128,7 +128,7 @@ def main(config):
         displayType = config.get("displayType", "colors")
 
         # New 2x wide styles take a completely separate render path.
-        if displayType == "wide3" or displayType == "wide4" or displayType == "wide6":
+        if displayType == "wide3" or displayType == "wide4":
             return render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_url)
 
         #logoType = config.get("logoType", "primary")
@@ -509,7 +509,7 @@ def main(config):
         # `supports2x: true` makes the server hand every style a 128x64 canvas.
         # The legacy 64x32 styles aren't responsive, so on a wide canvas pin them
         # to a crisp, centered 64x32 island instead of rendering broken top-left.
-        # (Wide 3/6 are the native 2x styles and use the full canvas.)
+        # (Wide 3/4 are the native 2x styles and use the full canvas.)
         if canvas.is2x() or canvas.width() > 64:
             root_child = render.Box(
                 width = canvas.width(),
@@ -557,10 +557,6 @@ displayOptions = [
     schema.Option(
         display = "Wide · 4 Games (2x)",
         value = "wide4",
-    ),
-    schema.Option(
-        display = "Wide · 6 Games (2x)",
-        value = "wide6",
     ),
 ]
 
@@ -722,7 +718,7 @@ def get_schema():
 
 def show_wide_options(displayType):
     # Team-colors background toggle only applies to the wide 2x styles.
-    if displayType == "wide3" or displayType == "wide4" or displayType == "wide6":
+    if displayType == "wide3" or displayType == "wide4":
         return [
             schema.Toggle(
                 id = "wide_team_colors",
@@ -873,7 +869,7 @@ def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_ur
     if not (canvas.is2x() or canvas.width() >= W_W):
         return wide_needs_2x()
 
-    perPage = {"wide3": 3, "wide4": 4, "wide6": 6}[displayType]
+    perPage = {"wide3": 3, "wide4": 4}[displayType]
     colors_on = config.bool("wide_team_colors", True)
     rotationSpeed = int(config.get("displaySpeed", DEFAULT_DISPLAY_SPEED))
     comp_label = get_comp_label(scoreboard_url, leagueAbbr)
@@ -895,10 +891,8 @@ def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_ur
     for pg in pages:
         if displayType == "wide3":
             frames.append(wide3_page(pg, comp_label, header_color, colors_on))
-        elif displayType == "wide4":
-            frames.append(wide4_page(pg, comp_label, header_color, colors_on))
         else:
-            frames.append(wide6_page(pg, comp_label, header_color, colors_on))
+            frames.append(wide4_page(pg, comp_label, header_color, colors_on))
 
     # Each page is one static frame; the per-frame delay is the rotation timer,
     # so every page in the window shows at least once per loop.
@@ -1224,14 +1218,10 @@ def wide3_center(g):
             render.Box(width = 2, height = 1),
             render.Text(content = g["right"]["score"], font = W_FONT_SCORE, color = g["right"]["score_color"]),
         ])
-        if g["is_live"]:
-            status = render.Row(cross_align = "center", children = [
-                render.Circle(color = W_LIVE, diameter = 3),
-                render.Box(width = 2, height = 1),
-                render.Text(content = g["status_text"], font = W3_STATUS_FONT, color = W_LIVE),
-            ])
-        else:
-            status = render.Text(content = g["status_text"], font = W3_STATUS_FONT, color = g["status_color"])
+
+        # The time already renders green for a live match, so it carries the
+        # in-progress signal on its own — no separate pulse dot needed.
+        status = render.Text(content = g["status_text"], font = W3_STATUS_FONT, color = g["status_color"])
         kids = [score_row, status]
     return render.Box(
         width = W3_CENTER_W,
@@ -1240,101 +1230,9 @@ def wide3_center(g):
         child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = kids),
     )
 
-# ---- Wide 6 ----------------------------------------------------------------
-
-def wide6_page(pg, comp_label, header_color, colors_on):
-    games = pg["games"]
-    n = len(games)
-    cols = 3
-    grid_rows = [games[r:r + cols] for r in range(0, n, cols)]
-    cell_w = (W_W - (cols - 1)) // cols  # 42, black gridlines between cells
-    body_h = W_H - W_HEADER_H  # 56
-    cell_h = (body_h - 1) // 2  # 27
-
-    row_widgets = []
-    for ri in range(len(grid_rows)):
-        if ri > 0:
-            row_widgets.append(render.Box(width = W_W, height = 1, color = W_BG))
-        cells = []
-        for ci in range(len(grid_rows[ri])):
-            if ci > 0:
-                cells.append(render.Box(width = 1, height = cell_h, color = W_BG))
-            cells.append(wide6_cell(grid_rows[ri][ci], colors_on, cell_w, cell_h))
-        row_widgets.append(render.Row(main_align = "center", cross_align = "center", children = cells))
-
-    body = render.Box(
-        width = W_W,
-        height = body_h,
-        child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = row_widgets),
-    )
-    return render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
-
-def wide6_cell(g, colors_on, w, h):
-    left = g["left"]
-    right = g["right"]
-    lc = left["color"] if colors_on else W_OFF_BG
-    rc = right["color"] if colors_on else W_OFF_BG
-    line_h = h // 2
-    stacked = render.Column(children = [
-        wide6_line(g, left, lc, line_h, w),
-        wide6_line(g, right, rc, h - line_h, w),
-    ])
-
-    # Finished games are self-evident (score + no pulse) and upcoming games carry
-    # their W-D-L, so neither needs an overlay. Exceptions: live cells get a green
-    # pulse dot, and a finished shootout gets a small "P" so the yellow winner on
-    # a drawn score makes sense (no room for the tally in this dense grid).
-    if g["state"] == "in":
-        corner = wide6_chip(g)
-    elif g["has_pen"]:
-        corner = render.Box(width = 7, height = 7, color = "#000b", child = render.Padding(pad = (2, 1, 2, 1), child = render.Text(content = "P", font = W_FONT_STATUS, color = W_FINAL)))
-    else:
-        return stacked
-    overlay = render.Box(
-        width = w,
-        height = h,
-        child = render.Column(expanded = True, main_align = "start", children = [
-            render.Row(expanded = True, main_align = "end", children = [corner]),
-        ]),
-    )
-    return render.Stack(children = [stacked, overlay])
-
-def wide6_line(g, side, bg, lh, w):
-    if g["state"] == "pre":
-        # Upcoming: code (kept) on the left, form (W-D-L) on the right. The flag is
-        # dropped here (no room for flag + code + record in a 42px cell). tb-8 code
-        # for normal records; a two-digit league record ("20-8-10") needs the
-        # narrower tom-thumb code to keep both from clipping.
-        code_font = W_FONT_CELL if len(side["record"]) <= 6 else W_FONT_STATUS
-        left_group = render.Text(content = side["code"], font = code_font, color = side["code_color"])
-        rightval = render.Text(content = side["record"], font = W_FONT_STATUS, color = W_WHITE)
-    else:
-        code = render.Text(content = side["code"], font = W_FONT_CELL, color = side["code_color"])
-        flag = render.Image(src = side["logo"], width = W6_FLAG, height = W6_FLAG)
-        left_group = render.Row(cross_align = "center", children = [flag, render.Box(width = 3, height = 1), code])
-        rightval = render.Text(content = side["score"], font = W_FONT_CELL, color = side["score_color"])
-    return render.Box(
-        width = w,
-        height = lh,
-        color = bg,
-        child = render.Padding(pad = (1, 0, 1, 0), child = render.Row(
-            expanded = True,
-            main_align = "space_between",
-            cross_align = "center",
-            children = [left_group, rightval],
-        )),
-    )
-
-def wide6_chip(g):
-    # Only called for in-progress cells (live or half-time).
-    if g["is_live"]:
-        return render.Padding(pad = (0, 1, 1, 0), child = render.Circle(color = W_LIVE, diameter = 4))
-    cw = len(g["status_text"]) * 5 + 5
-    return render.Box(width = cw, height = 7, color = "#000b", child = render.Padding(pad = (2, 1, 2, 1), child = render.Text(content = g["status_text"], font = W_FONT_STATUS, color = g["status_color"])))
-
 # ---- Wide 4 ----------------------------------------------------------------
 # A 2x2 grid. The cells (~63 wide) are roomy enough to keep the flag, code,
-# score/record AND a status line (FT/HT/clock/kickoff) that Wide 6 had to drop.
+# score/record AND a status line (FT/HT/clock/kickoff) below each game.
 
 def wide4_page(pg, comp_label, header_color, colors_on):
     games = pg["games"]
@@ -1377,7 +1275,7 @@ def wide4_cell(g, colors_on, w, h):
     ])
 
 def wide4_line(g, side, bg, lh, w):
-    flag = render.Image(src = side["logo"], width = W6_FLAG, height = W6_FLAG)
+    flag = render.Image(src = side["logo"], width = W4_FLAG, height = W4_FLAG)
     code = render.Text(content = side["code"], font = W_FONT_CELL, color = side["code_color"])
     if g["state"] == "pre":
         rightval = render.Text(content = side["record"], font = W_FONT_STATUS, color = W_WHITE)
@@ -1400,15 +1298,10 @@ def wide4_line(g, side, bg, lh, w):
 
 def wide4_status(g, w, h):
     # Black status footer with the game time/state centered: kickoff (upcoming),
-    # green dot + clock (live), HT (amber) or FT (grey).
+    # clock (live, green), HT (amber) or FT (grey). A live match already reads as
+    # in-progress from the green clock, so there's no separate pulse dot.
     if g["state"] == "pre":
         kids = [render.Text(content = g["kickoff"], font = W_FONT_STATUS, color = W_WHITE)]
-    elif g["is_live"]:
-        kids = [
-            render.Circle(color = W_LIVE, diameter = 3),
-            render.Box(width = 2, height = 1),
-            render.Text(content = g["status_text"], font = W_FONT_STATUS, color = W_LIVE),
-        ]
     else:
         kids = [render.Text(content = g["status_text"], font = W_FONT_STATUS, color = g["status_color"])]
     return render.Box(

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -73,7 +73,7 @@ W_DASH = "#5b6470"  # score dash
 W_HDR_BG = "#11151f"  # header bg (a hair lighter than black)
 W_HDR_RULE = "#232a38"  # header bottom rule
 W_STEEL = "#444b57"  # fallback for near-black team colors
-W_OFF_BG = "#1a1d24"  # team band when colors toggle is OFF
+W_OFF_BG = "#000000"  # team band when colors toggle is OFF (flag carries identity)
 
 # Fonts (bitmap, real sizes). Hero numerals re-derived to fit the 18-LED row:
 # terminus-16 + an 8-LED status will not co-exist in one row, so the hero score
@@ -81,7 +81,7 @@ W_OFF_BG = "#1a1d24"  # team band when colors toggle is OFF
 W_FONT_HEADER = "tb-8"
 W_FONT_CODE = "tb-8"
 W_FONT_REC = "tb-8"
-W_FONT_SCORE = "6x13"  # hero score / kickoff in Wide 3
+W_FONT_SCORE = "6x10"  # hero score / kickoff in Wide 3 (was 6x13 — toned down)
 W3_STATUS_FONT = "CG-pixel-3x5-mono"  # Wide 3 status line (5 LED, fits under 6x13)
 W_FONT_STATUS = "tom-thumb"  # Wide 6 status chips / records
 W_FONT_CELL = "tb-8"  # code + score in Wide 6 cells
@@ -1245,10 +1245,20 @@ def wide6_cell(g, colors_on, w, h):
         wide6_line(g, left, lc, line_h, w),
         wide6_line(g, right, rc, h - line_h, w),
     ])
+
+    # Finished games are self-evident from their score + lack of a live pulse, so
+    # no chip (an "FT" on every cell is just noise in the grid). Only live and
+    # upcoming cells get a chip: upcoming sits right-centered in the empty score
+    # column; live tucks into the top-right corner so the green clock stands out.
+    if g["state"] == "post":
+        return stacked
+    valign = "center" if g["state"] == "pre" else "start"
     overlay = render.Box(
         width = w,
         height = h,
-        child = render.Column(expanded = True, main_align = "center", cross_align = "end", children = [wide6_chip(g)]),
+        child = render.Column(expanded = True, main_align = valign, children = [
+            render.Row(expanded = True, main_align = "end", children = [wide6_chip(g)]),
+        ]),
     )
     return render.Stack(children = [stacked, overlay])
 
@@ -1277,6 +1287,16 @@ def wide6_line(g, side, bg, lh, w):
     )
 
 def wide6_chip(g):
+    if g["state"] == "post":
+        return render.Box(width = 1, height = 1)
+
+    # Live: a small green pulse dot in the corner. The cell already shows both
+    # scores; the exact minute is detail that belongs in Wide 3, and a dot keeps
+    # the dense grid uncluttered (a clock chip here would cover the home score).
+    if g["is_live"]:
+        return render.Padding(pad = (0, 1, 1, 0), child = render.Circle(color = W_LIVE, diameter = 4))
+
+    # Upcoming kickoff, or half-time: a small text chip on a translucent pad.
     if g["state"] == "pre":
         txt = g["kickoff"]
         color = W_WHITE
@@ -1289,14 +1309,5 @@ def wide6_chip(g):
     # A bare render.Box (no width/height) expands to fill its parent, which would
     # wash the whole cell with the chip's translucent black. Give it an explicit
     # content-sized box so it stays a small corner chip.
-    if g["is_live"]:
-        cw = len(txt) * 5 + 11
-        inner = render.Row(cross_align = "center", children = [
-            render.Circle(color = W_LIVE, diameter = 3),
-            render.Box(width = 1, height = 1),
-            render.Text(content = txt, font = W_FONT_STATUS, color = W_LIVE),
-        ])
-    else:
-        cw = len(txt) * 5 + 5
-        inner = render.Text(content = txt, font = W_FONT_STATUS, color = color)
-    return render.Box(width = cw, height = 7, color = "#000b", child = render.Padding(pad = (2, 1, 2, 1), child = inner))
+    cw = len(txt) * 5 + 5
+    return render.Box(width = cw, height = 7, color = "#000b", child = render.Padding(pad = (2, 1, 2, 1), child = render.Text(content = txt, font = W_FONT_STATUS, color = color)))

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -497,16 +497,31 @@ def main(config):
                     ],
                 )
 
+        anim = render.Animation(children = renderCategory)
+
+        # `supports2x: true` makes the server hand every style a 128x64 canvas.
+        # The legacy 64x32 styles aren't responsive, so on a wide canvas pin them
+        # to a crisp, centered 64x32 island instead of rendering broken top-left.
+        # (Wide 3/6 are the native 2x styles and use the full canvas.)
+        if canvas.is2x() or canvas.width() > 64:
+            root_child = render.Box(
+                width = canvas.width(),
+                height = canvas.height(),
+                color = "#000000",
+                child = render.Column(
+                    expanded = True,
+                    main_align = "center",
+                    cross_align = "center",
+                    children = [render.Box(width = 64, height = 32, child = anim)],
+                ),
+            )
+        else:
+            root_child = render.Column(children = [anim])
+
         return render.Root(
             delay = rotationSpeed,
             show_full_animation = True,
-            child = render.Column(
-                children = [
-                    render.Animation(
-                        children = renderCategory,
-                    ),
-                ],
-            ),
+            child = root_child,
         )
     else:
         return []
@@ -840,10 +855,11 @@ def get_cachable_data(url):
 # ============================================================================
 
 def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_url):
-    # These layouts are built for the native 128x64 (2x) canvas only. Detect 2x
-    # by actual canvas width (canvas.is2x() is unreliable here) so this works
-    # both in CLI testing (-w 128 -t 64) and on a real wide device.
-    if canvas.width() < W_W:
+    # These layouts need the native 128x64 (2x) canvas. The device signals 2x via
+    # canvas.is2x() (requires `supports2x: true` in manifest.yaml, or the server
+    # renders 1x); CLI `-w 128 -t 64` reports width 128 but not is2x. Accept
+    # either so it works on real wide hardware and in local render tests.
+    if not (canvas.is2x() or canvas.width() >= W_W):
         return wide_needs_2x()
 
     perPage = 3 if displayType == "wide3" else 6

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -941,16 +941,19 @@ def parse_game_wide(s, config, timezone):
     home = wide_side(competitors[0])
     away = wide_side(competitors[1])
 
+    # penalty shootout: scores present while pens are live AND after (FINAL_PEN).
+    # The regulation score stays in the score slot; the tally goes in the status
+    # ("PK 4-2" live / "FT 4-2" final) since 0(4)-0(2) won't fit the narrow center.
+    hp = competitors[0].get("shootoutScore", "0")
+    ap = competitors[1].get("shootoutScore", "0")
+    pen_final = type_name == "STATUS_FINAL_PEN"
+    pen_live = state == "in" and (hp != "0" or ap != "0")
+
     # winner (post only) — shown by yellow text, never a swapped background
     home_win = False
     away_win = False
     if state == "post" and type_name != "STATUS_POSTPONED":
-        if type_name == "STATUS_FINAL_PEN":
-            # Decided on penalties: keep the (drawn) regulation score clean in the
-            # glance views and signal the winner via yellow text. The shootout
-            # tally is too wide to fit the 34-LED center / mini cells.
-            hp = competitors[0].get("shootoutScore", "0")
-            ap = competitors[1].get("shootoutScore", "0")
+        if pen_final:
             home_win = int_or(hp) > int_or(ap)
             away_win = int_or(ap) > int_or(hp)
         else:
@@ -966,7 +969,11 @@ def parse_game_wide(s, config, timezone):
         status_color = W_FINAL
     elif state == "in":
         up = short_detail.upper()
-        if up.startswith("HT") or up.find("HALF") >= 0:
+        if pen_live:
+            status_text = "PENS"  # live shootout; a tally here would be stale, omit it
+            status_color = W_LIVE
+            is_live = True
+        elif up.startswith("HT") or up.find("HALF") >= 0:
             status_text = "HT"
             status_color = W_HALF
         else:
@@ -979,7 +986,7 @@ def parse_game_wide(s, config, timezone):
         home["score"] = ""
         away["score"] = ""
     else:  # post
-        status_text = "FT(p)" if type_name == "STATUS_FINAL_PEN" else "FT"
+        status_text = "FT"
         status_color = W_FINAL
 
     home["code_color"] = W_WIN if home_win else W_WHITE
@@ -990,8 +997,16 @@ def parse_game_wide(s, config, timezone):
     # team_sequence: which team sits on the left (home zone)
     if config.get("team_sequence", DEFAULT_TEAM_DISPLAY) == "home":
         left, right = home, away
+        lp, rp = hp, ap
     else:
         left, right = away, home
+        lp, rp = ap, hp
+
+    # final shootout: append the tally (display order) -> "FT 4-2". Live shootouts
+    # stay just "PENS" (the running tally would be stale between refreshes).
+    has_pen = pen_final
+    if pen_final:
+        status_text = status_text + " " + lp + "-" + rp
 
     return dict(
         state = state,
@@ -999,6 +1014,7 @@ def parse_game_wide(s, config, timezone):
         status_text = status_text,
         status_color = status_color,
         kickoff = kickoff,
+        has_pen = has_pen,
         day_key = day_key,
         date_text = date_text,
         left = left,
@@ -1265,15 +1281,20 @@ def wide6_cell(g, colors_on, w, h):
     ])
 
     # Finished games are self-evident (score + no pulse) and upcoming games carry
-    # their W-D-L in the lines, so neither needs an overlay. Only live cells get
-    # one: a green pulse dot in the top-right corner.
-    if g["state"] != "in":
+    # their W-D-L, so neither needs an overlay. Exceptions: live cells get a green
+    # pulse dot, and a finished shootout gets a small "P" so the yellow winner on
+    # a drawn score makes sense (no room for the tally in this dense grid).
+    if g["state"] == "in":
+        corner = wide6_chip(g)
+    elif g["has_pen"]:
+        corner = render.Box(width = 7, height = 7, color = "#000b", child = render.Padding(pad = (2, 1, 2, 1), child = render.Text(content = "P", font = W_FONT_STATUS, color = W_FINAL)))
+    else:
         return stacked
     overlay = render.Box(
         width = w,
         height = h,
         child = render.Column(expanded = True, main_align = "start", children = [
-            render.Row(expanded = True, main_align = "end", children = [wide6_chip(g)]),
+            render.Row(expanded = True, main_align = "end", children = [corner]),
         ]),
     )
     return render.Stack(children = [stacked, overlay])

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -14,7 +14,7 @@ Author: jvivona
 
 load("encoding/json.star", "json")
 load("http.star", "http")
-load("render.star", "render")
+load("render.star", "canvas", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
@@ -55,6 +55,46 @@ SHORTENED_WORDS = """
 }
 """
 
+# ============================================================================
+# Wide 2x layouts (display options #5 "Wide 3" and #6 "Wide 6")
+# Designed for the native 128x64 canvas. See design handoff README.
+# All sizes are in LED units (the real grid), not the mock's px.
+# ============================================================================
+
+# State / accent tokens (from the design handoff)
+W_BG = "#000000"  # pure black (LED off)
+W_WIN = "#ffe14d"  # winner text (yellow)
+W_WHITE = "#ffffff"  # loser / neutral text
+W_LIVE = "#2ee65f"  # in-progress (green)
+W_HALF = "#ffb02e"  # half-time (amber)
+W_FINAL = "#7f8794"  # final / muted label (grey)
+W_REC = "#8a93a3"  # W-D-L record muted on black
+W_DASH = "#5b6470"  # score dash
+W_HDR_BG = "#11151f"  # header bg (a hair lighter than black)
+W_HDR_RULE = "#232a38"  # header bottom rule
+W_STEEL = "#444b57"  # fallback for near-black team colors
+W_OFF_BG = "#1a1d24"  # team band when colors toggle is OFF
+
+# Fonts (bitmap, real sizes). Hero numerals re-derived to fit the 18-LED row:
+# terminus-16 + an 8-LED status will not co-exist in one row, so the hero score
+# uses 6x13 and the status uses tom-thumb. See README "Fidelity" note.
+W_FONT_HEADER = "tb-8"
+W_FONT_CODE = "tb-8"
+W_FONT_REC = "tb-8"
+W_FONT_SCORE = "6x13"  # hero score / kickoff in Wide 3
+W3_STATUS_FONT = "CG-pixel-3x5-mono"  # Wide 3 status line (5 LED, fits under 6x13)
+W_FONT_STATUS = "tom-thumb"  # Wide 6 status chips / records
+W_FONT_CELL = "tb-8"  # code + score in Wide 6 cells
+
+# Geometry (LED units)
+W_W = 128
+W_H = 64
+W_HEADER_H = 8  # 7 bg + 1 rule (all-caps day header has no descenders)
+W3_CENTER_W = 34  # fixed black score column in Wide 3
+W3_ROW_H = 18  # 3 rows * 18 + 2 * 1 divider == 56 body, exact
+W3_FLAG = 16  # flag/crest in Wide 3 zone
+W6_FLAG = 9  # flag/crest in Wide 6 cell line
+
 def main(config):
     LEAGUE_ABBR = json.decode(http.get(url = ABBR_URL, ttl_seconds = COMPS_TTL).body())
     renderCategory = []
@@ -72,12 +112,17 @@ def main(config):
         fwd_time = now + time.parse_duration("%dh" % (int(config.get("days_forward", 1)) * 24))
         date_range_search = "?dates=%s-%s" % (back_time.format("20060102"), (fwd_time.format("20060102")))
 
-    league = {API: API + selectedLeague + "/scoreboard" + date_range_search}
+    scoreboard_url = API + selectedLeague + "/scoreboard" + date_range_search
+    league = {API: scoreboard_url}
 
     scores = get_scores(league)
 
     if len(scores) > 0:
         displayType = config.get("displayType", "colors")
+
+        # New 2x wide styles (#5/#6) take a completely separate render path.
+        if displayType == "wide3" or displayType == "wide6":
+            return render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_url)
 
         #logoType = config.get("logoType", "primary")
         timeColor = config.get("displayTimeColor", "#FFF")
@@ -483,6 +528,14 @@ displayOptions = [
         display = "Retro",
         value = "retro",
     ),
+    schema.Option(
+        display = "Wide · 3 Games (2x)",
+        value = "wide3",
+    ),
+    schema.Option(
+        display = "Wide · 6 Games (2x)",
+        value = "wide6",
+    ),
 ]
 
 pregameOptions = [
@@ -592,6 +645,11 @@ def get_schema():
                 default = displayOptions[0].value,
                 options = displayOptions,
             ),
+            schema.Generated(
+                id = "wide_generated",
+                source = "displayType",
+                handler = show_wide_options,
+            ),
             schema.Color(
                 id = "displayTimeColor",
                 name = "Time Color",
@@ -635,6 +693,21 @@ def get_schema():
             ),
         ],
     )
+
+def show_wide_options(displayType):
+    # Team-colors background toggle only applies to the wide 2x styles.
+    if displayType == "wide3" or displayType == "wide6":
+        return [
+            schema.Toggle(
+                id = "wide_team_colors",
+                name = "Team color backgrounds",
+                desc = "Tint each team's area with its team color (off = black bands).",
+                icon = "palette",
+                default = True,
+            ),
+        ]
+    else:
+        return []
 
 def show_day_range(day_range):
     # need to do the string comparison here to make it consistent instead of converting to bool - its a whole thing
@@ -761,3 +834,453 @@ def get_cachable_data(url):
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
 
     return res.body()
+
+# ============================================================================
+# Wide 2x layouts — render path
+# ============================================================================
+
+def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_url):
+    # These layouts are built for the native 128x64 (2x) canvas only. Detect 2x
+    # by actual canvas width (canvas.is2x() is unreliable here) so this works
+    # both in CLI testing (-w 128 -t 64) and on a real wide device.
+    if canvas.width() < W_W:
+        return wide_needs_2x()
+
+    perPage = 3 if displayType == "wide3" else 6
+    colors_on = config.bool("wide_team_colors", True)
+    rotationSpeed = int(config.get("displaySpeed", DEFAULT_DISPLAY_SPEED))
+    round_label = get_round_label(scoreboard_url, leagueAbbr)
+
+    games = []
+    for s in scores:
+        g = parse_game_wide(s, config, timezone)
+        if g != None:
+            games.append(g)
+
+    pages = build_pages(games, perPage)
+    if len(pages) == 0:
+        return []
+
+    frames = []
+    for pg in pages:
+        if pg["page_count"] > 1:
+            right = "PG %d/%d" % (pg["page_num"], pg["page_count"])
+            right_color = W_WHITE
+        else:
+            right = round_label
+            right_color = W_REC
+        if displayType == "wide3":
+            frames.append(wide3_page(pg, right, right_color, colors_on))
+        else:
+            frames.append(wide6_page(pg, right, right_color, colors_on))
+
+    # Each page is one static frame; the per-frame delay is the rotation timer,
+    # so every page in the window shows at least once per loop.
+    return render.Root(
+        delay = rotationSpeed,
+        show_full_animation = True,
+        child = render.Column(children = [render.Animation(children = frames)]),
+    )
+
+def get_round_label(scoreboard_url, leagueAbbr):
+    # Cache-hit reuse of the scoreboard fetch just to read the competition round
+    # name (e.g. "GROUP STAGE") for the header context slot. Works for every
+    # league/tournament the app offers; falls back to the short league code.
+    data = json.decode(get_cachable_data(scoreboard_url))
+    leagues = data.get("leagues", [])
+    if len(leagues) > 0:
+        name = leagues[0].get("season", {}).get("type", {}).get("name", "")
+        if name != "":
+            return name.upper()
+    return leagueAbbr.upper()
+
+def parse_game_wide(s, config, timezone):
+    comp = s["competitions"][0]
+    competitors = comp["competitors"]
+    if len(competitors) < 2:
+        return None
+
+    state = s["status"]["type"]["state"]
+    type_name = s["status"]["type"].get("name", "")
+    short_detail = s["status"]["type"].get("shortDetail", "")
+
+    # local date for day grouping + header
+    dt = time.parse_time(s["date"], format = "2006-01-02T15:04Z").in_location(timezone)
+    day_key = dt.format("20060102")
+    day_label = dt.format("Mon · 2 Jan").upper()  # e.g. "SAT · 14 JUN"
+
+    home = wide_side(competitors[0])
+    away = wide_side(competitors[1])
+
+    # winner (post only) — shown by yellow text, never a swapped background
+    home_win = False
+    away_win = False
+    if state == "post" and type_name != "STATUS_POSTPONED":
+        if type_name == "STATUS_FINAL_PEN":
+            # Decided on penalties: keep the (drawn) regulation score clean in the
+            # glance views and signal the winner via yellow text. The shootout
+            # tally is too wide to fit the 34-LED center / mini cells.
+            hp = competitors[0].get("shootoutScore", "0")
+            ap = competitors[1].get("shootoutScore", "0")
+            home_win = int_or(hp) > int_or(ap)
+            away_win = int_or(ap) > int_or(hp)
+        else:
+            home_win = int_or(home["score"]) > int_or(away["score"])
+            away_win = int_or(away["score"]) > int_or(home["score"])
+
+    # status text + color + kickoff
+    is_live = False
+    kickoff = ""
+    if state == "pre":
+        kickoff = wide_kickoff(s["date"], config, timezone)
+        status_text = ""
+        status_color = W_FINAL
+    elif state == "in":
+        up = short_detail.upper()
+        if up.startswith("HT") or up.find("HALF") >= 0:
+            status_text = "HT"
+            status_color = W_HALF
+        else:
+            status_text = short_detail.strip()[:6]
+            status_color = W_LIVE
+            is_live = True
+    elif type_name == "STATUS_POSTPONED":
+        status_text = "PPD"
+        status_color = W_FINAL
+        home["score"] = ""
+        away["score"] = ""
+    else:  # post
+        status_text = "FT(p)" if type_name == "STATUS_FINAL_PEN" else "FT"
+        status_color = W_FINAL
+
+    home["code_color"] = W_WIN if home_win else W_WHITE
+    away["code_color"] = W_WIN if away_win else W_WHITE
+    home["score_color"] = W_WIN if home_win else W_WHITE
+    away["score_color"] = W_WIN if away_win else W_WHITE
+
+    # team_sequence: which team sits on the left (home zone)
+    if config.get("team_sequence", DEFAULT_TEAM_DISPLAY) == "home":
+        left, right = home, away
+    else:
+        left, right = away, home
+
+    return dict(
+        state = state,
+        is_live = is_live,
+        status_text = status_text,
+        status_color = status_color,
+        kickoff = kickoff,
+        day_key = day_key,
+        day_label = day_label,
+        left = left,
+        right = right,
+    )
+
+def wide_side(competitor):
+    team = competitor["team"]
+    name = team.get("name", "")
+    code = team.get("abbreviation", name[0:3].upper() if name != "" else "?")
+    logo_url = team.get("logo", "") or MISSING_LOGO
+    score = competitor.get("score", "")
+    record = ""
+    recs = competitor.get("records", None)
+    if recs != None and len(recs) > 0:
+        record = recs[0].get("summary", "")
+    return dict(
+        code = code[:3],
+        color = wide_team_color(team.get("color", "")),
+        logo = get_logoType(logo_url),
+        score = score,
+        record = record,
+        code_color = W_WHITE,
+        score_color = W_WHITE,
+    )
+
+def int_or(v):
+    if v != None and str(v).isdigit():
+        return int(v)
+    return 0
+
+def wide_kickoff(date_str, config, timezone):
+    t = time.parse_time(date_str, format = "2006-01-02T15:04Z").in_location(timezone)
+    if config.bool("is_24_hour_format", False):
+        return t.format("15:04")
+    return t.format("3:04PM")[:-1]  # strip trailing M -> "3:04P"
+
+HEX = "0123456789abcdef"
+
+def hex2(n):
+    # Starlark's % formatting has no width/zero-pad, so build hex bytes by hand.
+    if n < 0:
+        n = 0
+    if n > 255:
+        n = 255
+    return HEX[n // 16] + HEX[n % 16]
+
+def wide_team_color(hexcolor):
+    h = hexcolor.replace("#", "")
+    if len(h) != 6:
+        return W_STEEL
+    r = int(h[0:2], 16)
+    g = int(h[2:4], 16)
+    b = int(h[4:6], 16)
+    lum = (299 * r + 587 * g + 114 * b) // 1000
+
+    # near-black is invisible on a black panel -> steel
+    if lum < 55:
+        return W_STEEL
+
+    # too light/bright kills white & yellow text -> scale down to a mid lum
+    if lum > 125:
+        r = (r * 125) // lum
+        g = (g * 125) // lum
+        b = (b * 125) // lum
+    return "#" + hex2(r) + hex2(g) + hex2(b)
+
+def build_pages(games, perPage):
+    # Group by local day in feed (kickoff) order, chunk each day into pages of
+    # perPage, skip empty days, flatten day-by-day, page-by-page.
+    order = []
+    bucket = {}
+    for g in games:
+        k = g["day_key"]
+        if k not in bucket:
+            bucket[k] = []
+            order.append(k)
+        bucket[k].append(g)
+
+    pages = []
+    for k in order:
+        dgames = bucket[k]
+        n = len(dgames)
+        npages = (n + perPage - 1) // perPage
+        for p in range(npages):
+            pages.append(dict(
+                day_label = dgames[0]["day_label"],
+                games = dgames[p * perPage:(p + 1) * perPage],
+                page_num = p + 1,
+                page_count = npages,
+            ))
+    return pages
+
+# ---- shared chrome ---------------------------------------------------------
+
+def wide_header(day_label, right_text, right_color):
+    return render.Column(children = [
+        render.Box(
+            width = W_W,
+            height = W_HEADER_H - 1,
+            color = W_HDR_BG,
+            child = render.Row(
+                expanded = True,
+                main_align = "space_between",
+                cross_align = "center",
+                children = [
+                    render.Padding(pad = (2, 0, 0, 0), child = render.Text(content = day_label, font = W_FONT_HEADER, color = W_WHITE)),
+                    render.Padding(pad = (0, 0, 2, 0), child = render.Text(content = right_text, font = W_FONT_HEADER, color = right_color)),
+                ],
+            ),
+        ),
+        render.Box(width = W_W, height = 1, color = W_HDR_RULE),
+    ])
+
+def wide_needs_2x():
+    # 1x devices can't fit the wide layouts; explain rather than render garbage.
+    return render.Root(
+        child = render.Box(
+            width = 64,
+            height = 32,
+            color = W_BG,
+            child = render.Column(
+                expanded = True,
+                main_align = "center",
+                cross_align = "center",
+                children = [
+                    render.Text(content = "WIDE VIEW", font = "tb-8", color = W_WIN),
+                    render.Box(width = 1, height = 1),
+                    render.Text(content = "needs a 2x", font = "tom-thumb", color = W_WHITE),
+                    render.Text(content = "display", font = "tom-thumb", color = W_WHITE),
+                ],
+            ),
+        ),
+    )
+
+# ---- Wide 3 ----------------------------------------------------------------
+
+def wide3_page(pg, right_text, right_color, colors_on):
+    games = pg["games"]
+    rows = []
+    for i in range(len(games)):
+        if i > 0 and colors_on:
+            rows.append(render.Box(width = W_W, height = 1, color = W_BG))
+        rows.append(wide3_row(games[i], colors_on))
+    body = render.Box(
+        width = W_W,
+        height = W_H - W_HEADER_H,
+        child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = rows),
+    )
+    return render.Column(children = [wide_header(pg["day_label"], right_text, right_color), body])
+
+def wide3_row(g, colors_on):
+    left = g["left"]
+    right = g["right"]
+    lcolor = left["color"] if colors_on else W_OFF_BG
+    rcolor = right["color"] if colors_on else W_OFF_BG
+    zone_w = (W_W - W3_CENTER_W) // 2  # 47
+    return render.Row(
+        expanded = True,
+        cross_align = "center",
+        children = [
+            wide3_zone(left, lcolor, "left", g["state"], zone_w),
+            wide3_center(g),
+            wide3_zone(right, rcolor, "right", g["state"], zone_w),
+        ],
+    )
+
+def wide3_zone(side, bg, side_name, state, w):
+    flag = render.Image(src = side["logo"], width = W3_FLAG, height = W3_FLAG)
+    show_rec = state == "pre" and side["record"] != ""
+
+    # Pre-game: W-D-L record sits on its own line under the code (the 47-LED zone
+    # can't fit flag+code+record side by side). Post/live: just the code.
+    if show_rec:
+        idblock = render.Column(
+            cross_align = "start" if side_name == "left" else "end",
+            children = [
+                render.Text(content = side["code"], font = W_FONT_CODE, color = side["code_color"]),
+                render.Text(content = side["record"], font = W_FONT_STATUS, color = W_REC),
+            ],
+        )
+    else:
+        idblock = render.Text(content = side["code"], font = W_FONT_CODE, color = side["code_color"])
+
+    if side_name == "left":
+        inner = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [flag, render.Box(width = 4, height = 1), idblock])
+        pad = (2, 0, 0, 0)
+    else:
+        inner = render.Row(expanded = True, main_align = "end", cross_align = "center", children = [idblock, render.Box(width = 4, height = 1), flag])
+        pad = (0, 0, 2, 0)
+
+    return render.Box(width = w, height = W3_ROW_H, color = bg, child = render.Padding(pad = pad, child = inner))
+
+def wide3_center(g):
+    if g["state"] == "pre":
+        kids = [render.Text(content = g["kickoff"], font = W_FONT_SCORE, color = W_WHITE)]
+    else:
+        score_row = render.Row(cross_align = "center", children = [
+            render.Text(content = g["left"]["score"], font = W_FONT_SCORE, color = g["left"]["score_color"]),
+            render.Box(width = 3, height = 1),
+            render.Text(content = "-", font = W_FONT_SCORE, color = W_DASH),
+            render.Box(width = 3, height = 1),
+            render.Text(content = g["right"]["score"], font = W_FONT_SCORE, color = g["right"]["score_color"]),
+        ])
+        if g["is_live"]:
+            status = render.Row(cross_align = "center", children = [
+                render.Circle(color = W_LIVE, diameter = 3),
+                render.Box(width = 2, height = 1),
+                render.Text(content = g["status_text"], font = W3_STATUS_FONT, color = W_LIVE),
+            ])
+        else:
+            status = render.Text(content = g["status_text"], font = W3_STATUS_FONT, color = g["status_color"])
+        kids = [score_row, status]
+    return render.Box(
+        width = W3_CENTER_W,
+        height = W3_ROW_H,
+        color = W_BG,
+        child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = kids),
+    )
+
+# ---- Wide 6 ----------------------------------------------------------------
+
+def wide6_page(pg, right_text, right_color, colors_on):
+    games = pg["games"]
+    n = len(games)
+    cols = 3
+    grid_rows = [games[r:r + cols] for r in range(0, n, cols)]
+    cell_w = (W_W - (cols - 1)) // cols if colors_on else W_W // cols  # 42
+    body_h = W_H - W_HEADER_H  # 56
+    cell_h = (body_h - 1) // 2 if colors_on else body_h // 2  # 27
+
+    row_widgets = []
+    for ri in range(len(grid_rows)):
+        if ri > 0 and colors_on:
+            row_widgets.append(render.Box(width = W_W, height = 1, color = W_BG))
+        cells = []
+        for ci in range(len(grid_rows[ri])):
+            if ci > 0 and colors_on:
+                cells.append(render.Box(width = 1, height = cell_h, color = W_BG))
+            cells.append(wide6_cell(grid_rows[ri][ci], colors_on, cell_w, cell_h))
+        row_widgets.append(render.Row(main_align = "center", cross_align = "center", children = cells))
+
+    body = render.Box(
+        width = W_W,
+        height = body_h,
+        child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = row_widgets),
+    )
+    return render.Column(children = [wide_header(pg["day_label"], right_text, right_color), body])
+
+def wide6_cell(g, colors_on, w, h):
+    left = g["left"]
+    right = g["right"]
+    lc = left["color"] if colors_on else W_OFF_BG
+    rc = right["color"] if colors_on else W_OFF_BG
+    line_h = h // 2
+    stacked = render.Column(children = [
+        wide6_line(g, left, lc, line_h, w),
+        wide6_line(g, right, rc, h - line_h, w),
+    ])
+    overlay = render.Box(
+        width = w,
+        height = h,
+        child = render.Column(expanded = True, main_align = "center", cross_align = "end", children = [wide6_chip(g)]),
+    )
+    return render.Stack(children = [stacked, overlay])
+
+def wide6_line(g, side, bg, lh, w):
+    flag = render.Image(src = side["logo"], width = W6_FLAG, height = W6_FLAG)
+    code = render.Text(content = side["code"], font = W_FONT_CELL, color = side["code_color"])
+    if g["state"] == "pre":
+        # Dense glance view: upcoming cells lead with the kickoff (center chip);
+        # detailed W-D-L lives in Wide 3 where there's room for it.
+        rightval = render.Box(width = 1, height = 1)
+    else:
+        rightval = render.Text(content = side["score"], font = W_FONT_CELL, color = side["score_color"])
+    return render.Box(
+        width = w,
+        height = lh,
+        color = bg,
+        child = render.Padding(pad = (2, 0, 2, 0), child = render.Row(
+            expanded = True,
+            main_align = "space_between",
+            cross_align = "center",
+            children = [
+                render.Row(cross_align = "center", children = [flag, render.Box(width = 3, height = 1), code]),
+                rightval,
+            ],
+        )),
+    )
+
+def wide6_chip(g):
+    if g["state"] == "pre":
+        txt = g["kickoff"]
+        color = W_WHITE
+    else:
+        txt = g["status_text"]
+        color = g["status_color"]
+    if txt == "":
+        return render.Box(width = 1, height = 1)
+
+    # A bare render.Box (no width/height) expands to fill its parent, which would
+    # wash the whole cell with the chip's translucent black. Give it an explicit
+    # content-sized box so it stays a small corner chip.
+    if g["is_live"]:
+        cw = len(txt) * 5 + 11
+        inner = render.Row(cross_align = "center", children = [
+            render.Circle(color = W_LIVE, diameter = 3),
+            render.Box(width = 1, height = 1),
+            render.Text(content = txt, font = W_FONT_STATUS, color = W_LIVE),
+        ])
+    else:
+        cw = len(txt) * 5 + 5
+        inner = render.Text(content = txt, font = W_FONT_STATUS, color = color)
+    return render.Box(width = cw, height = 7, color = "#000b", child = render.Padding(pad = (2, 1, 2, 1), child = inner))

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -74,7 +74,7 @@ W_HDR_BG = "#11151f"  # header bg (a hair lighter than black)
 W_HDR_RULE = "#232a38"  # header bottom rule
 W_STEEL = "#444b57"  # fallback for near-black team colors
 W_OFF_BG = "#000000"  # team band when colors toggle is OFF (flag carries identity)
-W_TEAM_ALPHA = "b4"  # alpha on team-color bands so they read softer over black (~70%)
+W_TEAM_ALPHA = "80"  # alpha on team-color bands so they read softer over black (~50%)
 
 # Fonts (bitmap, real sizes). Hero numerals re-derived to fit the 18-LED row:
 # terminus-16 + an 8-LED status will not co-exist in one row, so the hero score
@@ -885,7 +885,11 @@ def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_ur
         return []
 
     frames = []
-    for pg in pages:
+    total = len(pages)
+    for i in range(total):
+        pg = pages[i]
+        pg["overall_index"] = i
+        pg["overall_total"] = total
         if displayType == "wide3":
             frames.append(wide3_page(pg, comp_label, header_color, colors_on))
         else:
@@ -1110,23 +1114,22 @@ def wide_header(comp_label, date_text, text_color):
     ])
 
 def with_page_dots(frame, pg):
-    # One dot per page of the current day, bottom-right; the current page is lit
-    # white, the rest dim. Only shown when the day spans more than one page.
-    if pg["page_count"] <= 1:
+    # One dot per page across the whole rotation, centered along the bottom; the
+    # current page is lit white, the rest dim. Only shown when there's >1 page.
+    total = pg["overall_total"]
+    if total <= 1:
         return frame
     dots = []
-    for i in range(pg["page_count"]):
+    for i in range(total):
         if i > 0:
             dots.append(render.Box(width = 2, height = 1))
-        dots.append(render.Circle(color = W_WHITE if i == pg["page_num"] - 1 else "#3a3f4a", diameter = 3))
-    cw = pg["page_count"] * 3 + (pg["page_count"] - 1) * 2 + 4
-    chip = render.Box(width = cw, height = 7, color = "#000a", child = render.Padding(pad = (2, 2, 2, 2), child = render.Row(cross_align = "center", children = dots)))
+        dots.append(render.Circle(color = W_WHITE if i == pg["overall_index"] else "#3a3f4a", diameter = 3))
+    cw = total * 3 + (total - 1) * 2 + 4
+    chip = render.Box(width = cw, height = 6, color = "#000a", child = render.Padding(pad = (2, 1, 2, 1), child = render.Row(cross_align = "center", children = dots)))
     overlay = render.Box(
         width = W_W,
         height = W_H,
-        child = render.Column(expanded = True, main_align = "end", children = [
-            render.Row(expanded = True, main_align = "end", children = [chip]),
-        ]),
+        child = render.Column(expanded = True, main_align = "end", cross_align = "center", children = [chip]),
     )
     return render.Stack(children = [frame, overlay])
 
@@ -1178,24 +1181,25 @@ def wide3_row(g, colors_on):
         expanded = True,
         cross_align = "center",
         children = [
-            wide3_zone(left, lcolor, "left", g["state"], zone_w),
+            wide3_zone(left, lcolor, "left", zone_w),
             wide3_center(g),
-            wide3_zone(right, rcolor, "right", g["state"], zone_w),
+            wide3_zone(right, rcolor, "right", zone_w),
         ],
     )
 
-def wide3_zone(side, bg, side_name, state, w):
+def wide3_zone(side, bg, side_name, w):
     flag = render.Image(src = side["logo"], width = W3_FLAG, height = W3_FLAG)
-    show_rec = state == "pre" and side["record"] != ""
+    show_rec = side["record"] != ""
 
-    # Pre-game: W-D-L record sits on its own line under the code (the 47-LED zone
-    # can't fit flag+code+record side by side). Post/live: just the code.
+    # W-D-L record sits on its own line under the code (the zone can't fit
+    # flag+code+record side by side). Shown for every state — the game's score or
+    # kickoff lives in the center column.
     if show_rec:
         idblock = render.Column(
             cross_align = "start" if side_name == "left" else "end",
             children = [
                 render.Text(content = side["code"], font = W_FONT_CODE, color = side["code_color"]),
-                render.Text(content = side["record"], font = W_FONT_STATUS, color = W_REC),
+                render.Text(content = side["record"], font = W_FONT_STATUS, color = W_WHITE),
             ],
         )
     else:
@@ -1302,7 +1306,7 @@ def wide6_line(g, side, bg, lh, w):
         # narrower tom-thumb code to keep both from clipping.
         code_font = W_FONT_CELL if len(side["record"]) <= 6 else W_FONT_STATUS
         left_group = render.Text(content = side["code"], font = code_font, color = side["code_color"])
-        rightval = render.Text(content = side["record"], font = W_FONT_STATUS, color = W_REC)
+        rightval = render.Text(content = side["record"], font = W_FONT_STATUS, color = W_WHITE)
     else:
         code = render.Text(content = side["code"], font = W_FONT_CELL, color = side["code_color"])
         flag = render.Image(src = side["logo"], width = W6_FLAG, height = W6_FLAG)

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -1129,9 +1129,9 @@ def with_page_dots(frame, pg):
     for i in range(total):
         if i > 0:
             dots.append(render.Box(width = 2, height = 1))
-        dots.append(render.Circle(color = W_WHITE if i == pg["overall_index"] else "#3a3f4a", diameter = 3))
-    cw = total * 3 + (total - 1) * 2 + 4
-    chip = render.Box(width = cw, height = 6, color = "#000a", child = render.Padding(pad = (2, 1, 2, 1), child = render.Row(cross_align = "center", children = dots)))
+        dots.append(render.Circle(color = W_WHITE if i == pg["overall_index"] else "#3a3f4a", diameter = 2))
+    cw = total * 2 + (total - 1) * 2 + 4
+    chip = render.Box(width = cw, height = 5, color = "#000a", child = render.Padding(pad = (2, 1, 2, 1), child = render.Row(cross_align = "center", children = dots)))
     overlay = render.Box(
         width = W_W,
         height = W_H,

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -73,7 +73,10 @@ W_DASH = "#5b6470"  # score dash
 W_HDR_BG = "#11151f"  # header bg (a hair lighter than black)
 W_HDR_RULE = "#232a38"  # header bottom rule
 W_STEEL = "#444b57"  # fallback for near-black team colors
-W_OFF_BG = "#000000"  # team band when colors toggle is OFF (flag carries identity)
+
+# Game box when the colors toggle is OFF, so games read as separate boxes (split
+# by the black gridlines) instead of blending into one black field.
+W_OFF_BG = "#3b414c"
 W_TEAM_ALPHA = "80"  # alpha on team-color bands so they read softer over black (~50%)
 
 # Fonts (bitmap, real sizes). Hero numerals re-derived to fit the 18-LED row:
@@ -1139,7 +1142,7 @@ def wide3_page(pg, comp_label, header_color, colors_on):
     games = pg["games"]
     rows = []
     for i in range(len(games)):
-        if i > 0 and colors_on:
+        if i > 0:
             rows.append(render.Box(width = W_W, height = 1, color = W_BG))
         rows.append(wide3_row(games[i], colors_on))
     body = render.Box(
@@ -1228,17 +1231,17 @@ def wide6_page(pg, comp_label, header_color, colors_on):
     n = len(games)
     cols = 3
     grid_rows = [games[r:r + cols] for r in range(0, n, cols)]
-    cell_w = (W_W - (cols - 1)) // cols if colors_on else W_W // cols  # 42
+    cell_w = (W_W - (cols - 1)) // cols  # 42, black gridlines between cells
     body_h = W_H - W_HEADER_H  # 56
-    cell_h = (body_h - 1) // 2 if colors_on else body_h // 2  # 27
+    cell_h = (body_h - 1) // 2  # 27
 
     row_widgets = []
     for ri in range(len(grid_rows)):
-        if ri > 0 and colors_on:
+        if ri > 0:
             row_widgets.append(render.Box(width = W_W, height = 1, color = W_BG))
         cells = []
         for ci in range(len(grid_rows[ri])):
-            if ci > 0 and colors_on:
+            if ci > 0:
                 cells.append(render.Box(width = 1, height = cell_h, color = W_BG))
             cells.append(wide6_cell(grid_rows[ri][ci], colors_on, cell_w, cell_h))
         row_widgets.append(render.Row(main_align = "center", cross_align = "center", children = cells))
@@ -1317,17 +1320,17 @@ def wide4_page(pg, comp_label, header_color, colors_on):
     n = len(games)
     cols = 2
     grid_rows = [games[r:r + cols] for r in range(0, n, cols)]
-    cell_w = (W_W - (cols - 1)) // cols if colors_on else W_W // cols  # 63
+    cell_w = (W_W - (cols - 1)) // cols  # 63, black gridlines between cells
     body_h = W_H - W_HEADER_H  # 56
-    cell_h = (body_h - 1) // 2 if colors_on else body_h // 2  # 27
+    cell_h = (body_h - 1) // 2  # 27
 
     row_widgets = []
     for ri in range(len(grid_rows)):
-        if ri > 0 and colors_on:
+        if ri > 0:
             row_widgets.append(render.Box(width = W_W, height = 1, color = W_BG))
         cells = []
         for ci in range(len(grid_rows[ri])):
-            if ci > 0 and colors_on:
+            if ci > 0:
                 cells.append(render.Box(width = 1, height = cell_h, color = W_BG))
             cells.append(wide4_cell(grid_rows[ri][ci], colors_on, cell_w, cell_h))
         row_widgets.append(render.Row(main_align = "center", cross_align = "center", children = cells))

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -124,8 +124,8 @@ def main(config):
     if len(scores) > 0:
         displayType = config.get("displayType", "colors")
 
-        # New 2x wide styles (#5/#6) take a completely separate render path.
-        if displayType == "wide3" or displayType == "wide6":
+        # New 2x wide styles take a completely separate render path.
+        if displayType == "wide3" or displayType == "wide4" or displayType == "wide6":
             return render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_url)
 
         #logoType = config.get("logoType", "primary")
@@ -552,6 +552,10 @@ displayOptions = [
         value = "wide3",
     ),
     schema.Option(
+        display = "Wide · 4 Games (2x)",
+        value = "wide4",
+    ),
+    schema.Option(
         display = "Wide · 6 Games (2x)",
         value = "wide6",
     ),
@@ -715,7 +719,7 @@ def get_schema():
 
 def show_wide_options(displayType):
     # Team-colors background toggle only applies to the wide 2x styles.
-    if displayType == "wide3" or displayType == "wide6":
+    if displayType == "wide3" or displayType == "wide4" or displayType == "wide6":
         return [
             schema.Toggle(
                 id = "wide_team_colors",
@@ -866,7 +870,7 @@ def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_ur
     if not (canvas.is2x() or canvas.width() >= W_W):
         return wide_needs_2x()
 
-    perPage = 3 if displayType == "wide3" else 6
+    perPage = {"wide3": 3, "wide4": 4, "wide6": 6}[displayType]
     colors_on = config.bool("wide_team_colors", True)
     rotationSpeed = int(config.get("displaySpeed", DEFAULT_DISPLAY_SPEED))
     comp_label = get_comp_label(scoreboard_url, leagueAbbr)
@@ -892,6 +896,8 @@ def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_ur
         pg["overall_total"] = total
         if displayType == "wide3":
             frames.append(wide3_page(pg, comp_label, header_color, colors_on))
+        elif displayType == "wide4":
+            frames.append(wide4_page(pg, comp_label, header_color, colors_on))
         else:
             frames.append(wide6_page(pg, comp_label, header_color, colors_on))
 
@@ -1330,3 +1336,90 @@ def wide6_chip(g):
         return render.Padding(pad = (0, 1, 1, 0), child = render.Circle(color = W_LIVE, diameter = 4))
     cw = len(g["status_text"]) * 5 + 5
     return render.Box(width = cw, height = 7, color = "#000b", child = render.Padding(pad = (2, 1, 2, 1), child = render.Text(content = g["status_text"], font = W_FONT_STATUS, color = g["status_color"])))
+
+# ---- Wide 4 ----------------------------------------------------------------
+# A 2x2 grid. The cells (~63 wide) are roomy enough to keep the flag, code,
+# score/record AND a status line (FT/HT/clock/kickoff) that Wide 6 had to drop.
+
+def wide4_page(pg, comp_label, header_color, colors_on):
+    games = pg["games"]
+    n = len(games)
+    cols = 2
+    grid_rows = [games[r:r + cols] for r in range(0, n, cols)]
+    cell_w = (W_W - (cols - 1)) // cols if colors_on else W_W // cols  # 63
+    body_h = W_H - W_HEADER_H  # 56
+    cell_h = (body_h - 1) // 2 if colors_on else body_h // 2  # 27
+
+    row_widgets = []
+    for ri in range(len(grid_rows)):
+        if ri > 0 and colors_on:
+            row_widgets.append(render.Box(width = W_W, height = 1, color = W_BG))
+        cells = []
+        for ci in range(len(grid_rows[ri])):
+            if ci > 0 and colors_on:
+                cells.append(render.Box(width = 1, height = cell_h, color = W_BG))
+            cells.append(wide4_cell(grid_rows[ri][ci], colors_on, cell_w, cell_h))
+        row_widgets.append(render.Row(main_align = "center", cross_align = "center", children = cells))
+
+    body = render.Box(
+        width = W_W,
+        height = body_h,
+        child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = row_widgets),
+    )
+    frame = render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
+    return with_page_dots(frame, pg)
+
+def wide4_cell(g, colors_on, w, h):
+    left = g["left"]
+    right = g["right"]
+    lc = left["color"] if colors_on else W_OFF_BG
+    rc = right["color"] if colors_on else W_OFF_BG
+    status_h = 7
+    line_h = (h - status_h) // 2
+    return render.Column(children = [
+        wide4_line(g, left, lc, line_h, w),
+        wide4_line(g, right, rc, h - status_h - line_h, w),
+        wide4_status(g, w, status_h),
+    ])
+
+def wide4_line(g, side, bg, lh, w):
+    flag = render.Image(src = side["logo"], width = W6_FLAG, height = W6_FLAG)
+    code = render.Text(content = side["code"], font = W_FONT_CELL, color = side["code_color"])
+    if g["state"] == "pre":
+        rightval = render.Text(content = side["record"], font = W_FONT_STATUS, color = W_WHITE)
+    else:
+        rightval = render.Text(content = side["score"], font = W_FONT_CELL, color = side["score_color"])
+    return render.Box(
+        width = w,
+        height = lh,
+        color = bg,
+        child = render.Padding(pad = (2, 0, 2, 0), child = render.Row(
+            expanded = True,
+            main_align = "space_between",
+            cross_align = "center",
+            children = [
+                render.Row(cross_align = "center", children = [flag, render.Box(width = 3, height = 1), code]),
+                rightval,
+            ],
+        )),
+    )
+
+def wide4_status(g, w, h):
+    # Black status footer with the game time/state centered: kickoff (upcoming),
+    # green dot + clock (live), HT (amber) or FT (grey).
+    if g["state"] == "pre":
+        kids = [render.Text(content = g["kickoff"], font = W_FONT_STATUS, color = W_WHITE)]
+    elif g["is_live"]:
+        kids = [
+            render.Circle(color = W_LIVE, diameter = 3),
+            render.Box(width = 2, height = 1),
+            render.Text(content = g["status_text"], font = W_FONT_STATUS, color = W_LIVE),
+        ]
+    else:
+        kids = [render.Text(content = g["status_text"], font = W_FONT_STATUS, color = g["status_color"])]
+    return render.Box(
+        width = w,
+        height = h,
+        color = W_BG,
+        child = render.Row(expanded = True, main_align = "center", cross_align = "center", children = kids),
+    )

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -74,6 +74,7 @@ W_HDR_BG = "#11151f"  # header bg (a hair lighter than black)
 W_HDR_RULE = "#232a38"  # header bottom rule
 W_STEEL = "#444b57"  # fallback for near-black team colors
 W_OFF_BG = "#000000"  # team band when colors toggle is OFF (flag carries identity)
+W_TEAM_ALPHA = "b4"  # alpha on team-color bands so they read softer over black (~70%)
 
 # Fonts (bitmap, real sizes). Hero numerals re-derived to fit the 18-LED row:
 # terminus-16 + an 8-LED status will not co-exist in one row, so the hero score
@@ -90,7 +91,10 @@ W_FONT_CELL = "tb-8"  # code + score in Wide 6 cells
 W_W = 128
 W_H = 64
 W_HEADER_H = 8  # 7 bg + 1 rule (all-caps day header has no descenders)
-W3_CENTER_W = 34  # fixed black score column in Wide 3
+
+# Narrow center score column in Wide 3, to widen the team zones so a two-digit
+# W-D-L record ("20-8-10") clears the center.
+W3_CENTER_W = 26
 W3_ROW_H = 18  # 3 rows * 18 + 2 * 1 divider == 56 body, exact
 W3_FLAG = 16  # flag/crest in Wide 3 zone
 W6_FLAG = 9  # flag/crest in Wide 6 cell line
@@ -865,7 +869,10 @@ def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_ur
     perPage = 3 if displayType == "wide3" else 6
     colors_on = config.bool("wide_team_colors", True)
     rotationSpeed = int(config.get("displaySpeed", DEFAULT_DISPLAY_SPEED))
-    round_label = get_round_label(scoreboard_url, leagueAbbr)
+    comp_label = get_comp_label(scoreboard_url, leagueAbbr)
+
+    # Header (competition + date) color, so back-to-back apps can be tinted apart.
+    header_color = config.get("displayTimeColor", "#FFF")
 
     games = []
     for s in scores:
@@ -879,16 +886,10 @@ def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_ur
 
     frames = []
     for pg in pages:
-        if pg["page_count"] > 1:
-            right = "PG %d/%d" % (pg["page_num"], pg["page_count"])
-            right_color = W_WHITE
-        else:
-            right = round_label
-            right_color = W_REC
         if displayType == "wide3":
-            frames.append(wide3_page(pg, right, right_color, colors_on))
+            frames.append(wide3_page(pg, comp_label, header_color, colors_on))
         else:
-            frames.append(wide6_page(pg, right, right_color, colors_on))
+            frames.append(wide6_page(pg, comp_label, header_color, colors_on))
 
     # Each page is one static frame; the per-frame delay is the rotation timer,
     # so every page in the window shows at least once per loop.
@@ -898,17 +899,17 @@ def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_ur
         child = render.Column(children = [render.Animation(children = frames)]),
     )
 
-def get_round_label(scoreboard_url, leagueAbbr):
-    # Cache-hit reuse of the scoreboard fetch just to read the competition round
-    # name (e.g. "GROUP STAGE") for the header context slot. Works for every
-    # league/tournament the app offers; falls back to the short league code.
+def get_comp_label(scoreboard_url, leagueAbbr):
+    # Cache-hit reuse of the scoreboard fetch just to read the competition name
+    # (leagues[0].abbreviation, e.g. "FIFA World Cup") for the header. Works for
+    # every league/tournament the app offers; falls back to the short league code.
     data = json.decode(get_cachable_data(scoreboard_url))
     leagues = data.get("leagues", [])
     if len(leagues) > 0:
-        name = leagues[0].get("season", {}).get("type", {}).get("name", "")
-        if name != "":
-            return name.upper()
-    return leagueAbbr.upper()
+        abbr = leagues[0].get("abbreviation", "")
+        if abbr != "":
+            return abbr
+    return leagueAbbr
 
 def parse_game_wide(s, config, timezone):
     comp = s["competitions"][0]
@@ -920,10 +921,13 @@ def parse_game_wide(s, config, timezone):
     type_name = s["status"]["type"].get("name", "")
     short_detail = s["status"]["type"].get("shortDetail", "")
 
-    # local date for day grouping + header
+    # local date for day grouping + header (short, no weekday)
     dt = time.parse_time(s["date"], format = "2006-01-02T15:04Z").in_location(timezone)
     day_key = dt.format("20060102")
-    day_label = dt.format("Mon · 2 Jan").upper()  # e.g. "SAT · 14 JUN"
+    if config.bool("is_us_date_format", False):
+        date_text = dt.format("1/2")  # e.g. "6/17"
+    else:
+        date_text = dt.format("2 Jan")  # e.g. "17 Jun"
 
     home = wide_side(competitors[0])
     away = wide_side(competitors[1])
@@ -987,7 +991,7 @@ def parse_game_wide(s, config, timezone):
         status_color = status_color,
         kickoff = kickoff,
         day_key = day_key,
-        day_label = day_label,
+        date_text = date_text,
         left = left,
         right = right,
     )
@@ -1034,9 +1038,12 @@ def hex2(n):
     return HEX[n // 16] + HEX[n % 16]
 
 def wide_team_color(hexcolor):
+    # Returned with an alpha suffix so the band softens against the black panel
+    # (same idea as the legacy "colors" style's 77 alpha), keeping white/yellow
+    # text readable.
     h = hexcolor.replace("#", "")
     if len(h) != 6:
-        return W_STEEL
+        return W_STEEL + W_TEAM_ALPHA
     r = int(h[0:2], 16)
     g = int(h[2:4], 16)
     b = int(h[4:6], 16)
@@ -1044,14 +1051,14 @@ def wide_team_color(hexcolor):
 
     # near-black is invisible on a black panel -> steel
     if lum < 55:
-        return W_STEEL
+        return W_STEEL + W_TEAM_ALPHA
 
     # too light/bright kills white & yellow text -> scale down to a mid lum
     if lum > 125:
         r = (r * 125) // lum
         g = (g * 125) // lum
         b = (b * 125) // lum
-    return "#" + hex2(r) + hex2(g) + hex2(b)
+    return "#" + hex2(r) + hex2(g) + hex2(b) + W_TEAM_ALPHA
 
 def build_pages(games, perPage):
     # Group by local day in feed (kickoff) order, chunk each day into pages of
@@ -1072,7 +1079,7 @@ def build_pages(games, perPage):
         npages = (n + perPage - 1) // perPage
         for p in range(npages):
             pages.append(dict(
-                day_label = dgames[0]["day_label"],
+                date_text = dgames[0]["date_text"],
                 games = dgames[p * perPage:(p + 1) * perPage],
                 page_num = p + 1,
                 page_count = npages,
@@ -1081,7 +1088,9 @@ def build_pages(games, perPage):
 
 # ---- shared chrome ---------------------------------------------------------
 
-def wide_header(day_label, right_text, right_color):
+def wide_header(comp_label, date_text, text_color):
+    # Competition (what you're looking at) on the left, short date on the right.
+    # Both take the user's "Time Color" so back-to-back apps can be tinted apart.
     return render.Column(children = [
         render.Box(
             width = W_W,
@@ -1092,13 +1101,34 @@ def wide_header(day_label, right_text, right_color):
                 main_align = "space_between",
                 cross_align = "center",
                 children = [
-                    render.Padding(pad = (2, 0, 0, 0), child = render.Text(content = day_label, font = W_FONT_HEADER, color = W_WHITE)),
-                    render.Padding(pad = (0, 0, 2, 0), child = render.Text(content = right_text, font = W_FONT_HEADER, color = right_color)),
+                    render.Padding(pad = (2, 0, 0, 0), child = render.Text(content = comp_label, font = W_FONT_HEADER, color = text_color)),
+                    render.Padding(pad = (0, 0, 2, 0), child = render.Text(content = date_text, font = W_FONT_HEADER, color = text_color)),
                 ],
             ),
         ),
         render.Box(width = W_W, height = 1, color = W_HDR_RULE),
     ])
+
+def with_page_dots(frame, pg):
+    # One dot per page of the current day, bottom-right; the current page is lit
+    # white, the rest dim. Only shown when the day spans more than one page.
+    if pg["page_count"] <= 1:
+        return frame
+    dots = []
+    for i in range(pg["page_count"]):
+        if i > 0:
+            dots.append(render.Box(width = 2, height = 1))
+        dots.append(render.Circle(color = W_WHITE if i == pg["page_num"] - 1 else "#3a3f4a", diameter = 3))
+    cw = pg["page_count"] * 3 + (pg["page_count"] - 1) * 2 + 4
+    chip = render.Box(width = cw, height = 7, color = "#000a", child = render.Padding(pad = (2, 2, 2, 2), child = render.Row(cross_align = "center", children = dots)))
+    overlay = render.Box(
+        width = W_W,
+        height = W_H,
+        child = render.Column(expanded = True, main_align = "end", children = [
+            render.Row(expanded = True, main_align = "end", children = [chip]),
+        ]),
+    )
+    return render.Stack(children = [frame, overlay])
 
 def wide_needs_2x():
     # 1x devices can't fit the wide layouts; explain rather than render garbage.
@@ -1123,7 +1153,7 @@ def wide_needs_2x():
 
 # ---- Wide 3 ----------------------------------------------------------------
 
-def wide3_page(pg, right_text, right_color, colors_on):
+def wide3_page(pg, comp_label, header_color, colors_on):
     games = pg["games"]
     rows = []
     for i in range(len(games)):
@@ -1135,7 +1165,8 @@ def wide3_page(pg, right_text, right_color, colors_on):
         height = W_H - W_HEADER_H,
         child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = rows),
     )
-    return render.Column(children = [wide_header(pg["day_label"], right_text, right_color), body])
+    frame = render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
+    return with_page_dots(frame, pg)
 
 def wide3_row(g, colors_on):
     left = g["left"]
@@ -1181,13 +1212,15 @@ def wide3_zone(side, bg, side_name, state, w):
 
 def wide3_center(g):
     if g["state"] == "pre":
-        kids = [render.Text(content = g["kickoff"], font = W_FONT_SCORE, color = W_WHITE)]
+        # tb-8 (not the hero 6x10) so a 6-char kickoff like "12:00A" fits the
+        # narrow center column.
+        kids = [render.Text(content = g["kickoff"], font = W_FONT_HEADER, color = W_WHITE)]
     else:
         score_row = render.Row(cross_align = "center", children = [
             render.Text(content = g["left"]["score"], font = W_FONT_SCORE, color = g["left"]["score_color"]),
-            render.Box(width = 3, height = 1),
+            render.Box(width = 2, height = 1),
             render.Text(content = "-", font = W_FONT_SCORE, color = W_DASH),
-            render.Box(width = 3, height = 1),
+            render.Box(width = 2, height = 1),
             render.Text(content = g["right"]["score"], font = W_FONT_SCORE, color = g["right"]["score_color"]),
         ])
         if g["is_live"]:
@@ -1208,7 +1241,7 @@ def wide3_center(g):
 
 # ---- Wide 6 ----------------------------------------------------------------
 
-def wide6_page(pg, right_text, right_color, colors_on):
+def wide6_page(pg, comp_label, header_color, colors_on):
     games = pg["games"]
     n = len(games)
     cols = 3
@@ -1233,7 +1266,8 @@ def wide6_page(pg, right_text, right_color, colors_on):
         height = body_h,
         child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = row_widgets),
     )
-    return render.Column(children = [wide_header(pg["day_label"], right_text, right_color), body])
+    frame = render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
+    return with_page_dots(frame, pg)
 
 def wide6_cell(g, colors_on, w, h):
     left = g["left"]
@@ -1246,68 +1280,49 @@ def wide6_cell(g, colors_on, w, h):
         wide6_line(g, right, rc, h - line_h, w),
     ])
 
-    # Finished games are self-evident from their score + lack of a live pulse, so
-    # no chip (an "FT" on every cell is just noise in the grid). Only live and
-    # upcoming cells get a chip: upcoming sits right-centered in the empty score
-    # column; live tucks into the top-right corner so the green clock stands out.
-    if g["state"] == "post":
+    # Finished games are self-evident (score + no pulse) and upcoming games carry
+    # their W-D-L in the lines, so neither needs an overlay. Only live cells get
+    # one: a green pulse dot in the top-right corner.
+    if g["state"] != "in":
         return stacked
-    valign = "center" if g["state"] == "pre" else "start"
     overlay = render.Box(
         width = w,
         height = h,
-        child = render.Column(expanded = True, main_align = valign, children = [
+        child = render.Column(expanded = True, main_align = "start", children = [
             render.Row(expanded = True, main_align = "end", children = [wide6_chip(g)]),
         ]),
     )
     return render.Stack(children = [stacked, overlay])
 
 def wide6_line(g, side, bg, lh, w):
-    flag = render.Image(src = side["logo"], width = W6_FLAG, height = W6_FLAG)
-    code = render.Text(content = side["code"], font = W_FONT_CELL, color = side["code_color"])
     if g["state"] == "pre":
-        # Dense glance view: upcoming cells lead with the kickoff (center chip);
-        # detailed W-D-L lives in Wide 3 where there's room for it.
-        rightval = render.Box(width = 1, height = 1)
+        # Upcoming: code (kept) on the left, form (W-D-L) on the right. The flag is
+        # dropped here (no room for flag + code + record in a 42px cell). tb-8 code
+        # for normal records; a two-digit league record ("20-8-10") needs the
+        # narrower tom-thumb code to keep both from clipping.
+        code_font = W_FONT_CELL if len(side["record"]) <= 6 else W_FONT_STATUS
+        left_group = render.Text(content = side["code"], font = code_font, color = side["code_color"])
+        rightval = render.Text(content = side["record"], font = W_FONT_STATUS, color = W_REC)
     else:
+        code = render.Text(content = side["code"], font = W_FONT_CELL, color = side["code_color"])
+        flag = render.Image(src = side["logo"], width = W6_FLAG, height = W6_FLAG)
+        left_group = render.Row(cross_align = "center", children = [flag, render.Box(width = 3, height = 1), code])
         rightval = render.Text(content = side["score"], font = W_FONT_CELL, color = side["score_color"])
     return render.Box(
         width = w,
         height = lh,
         color = bg,
-        child = render.Padding(pad = (2, 0, 2, 0), child = render.Row(
+        child = render.Padding(pad = (1, 0, 1, 0), child = render.Row(
             expanded = True,
             main_align = "space_between",
             cross_align = "center",
-            children = [
-                render.Row(cross_align = "center", children = [flag, render.Box(width = 3, height = 1), code]),
-                rightval,
-            ],
+            children = [left_group, rightval],
         )),
     )
 
 def wide6_chip(g):
-    if g["state"] == "post":
-        return render.Box(width = 1, height = 1)
-
-    # Live: a small green pulse dot in the corner. The cell already shows both
-    # scores; the exact minute is detail that belongs in Wide 3, and a dot keeps
-    # the dense grid uncluttered (a clock chip here would cover the home score).
+    # Only called for in-progress cells (live or half-time).
     if g["is_live"]:
         return render.Padding(pad = (0, 1, 1, 0), child = render.Circle(color = W_LIVE, diameter = 4))
-
-    # Upcoming kickoff, or half-time: a small text chip on a translucent pad.
-    if g["state"] == "pre":
-        txt = g["kickoff"]
-        color = W_WHITE
-    else:
-        txt = g["status_text"]
-        color = g["status_color"]
-    if txt == "":
-        return render.Box(width = 1, height = 1)
-
-    # A bare render.Box (no width/height) expands to fill its parent, which would
-    # wash the whole cell with the chip's translucent black. Give it an explicit
-    # content-sized box so it stays a small corner chip.
-    cw = len(txt) * 5 + 5
-    return render.Box(width = cw, height = 7, color = "#000b", child = render.Padding(pad = (2, 1, 2, 1), child = render.Text(content = txt, font = W_FONT_STATUS, color = color)))
+    cw = len(g["status_text"]) * 5 + 5
+    return render.Box(width = cw, height = 7, color = "#000b", child = render.Padding(pad = (2, 1, 2, 1), child = render.Text(content = g["status_text"], font = W_FONT_STATUS, color = g["status_color"])))

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -76,7 +76,7 @@ W_STEEL = "#444b57"  # fallback for near-black team colors
 
 # Game box when the colors toggle is OFF, so games read as separate boxes (split
 # by the black gridlines) instead of blending into one black field.
-W_OFF_BG = "#3b414c"
+W_OFF_BG = "#262b33"
 W_TEAM_ALPHA = "80"  # alpha on team-color bands so they read softer over black (~50%)
 
 # Fonts (bitmap, real sizes). Hero numerals re-derived to fit the 18-LED row:

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -889,11 +889,7 @@ def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_ur
         return []
 
     frames = []
-    total = len(pages)
-    for i in range(total):
-        pg = pages[i]
-        pg["overall_index"] = i
-        pg["overall_total"] = total
+    for pg in pages:
         if displayType == "wide3":
             frames.append(wide3_page(pg, comp_label, header_color, colors_on))
         elif displayType == "wide4":
@@ -1085,14 +1081,11 @@ def build_pages(games, perPage):
     pages = []
     for k in order:
         dgames = bucket[k]
-        n = len(dgames)
-        npages = (n + perPage - 1) // perPage
+        npages = (len(dgames) + perPage - 1) // perPage
         for p in range(npages):
             pages.append(dict(
                 date_text = dgames[0]["date_text"],
                 games = dgames[p * perPage:(p + 1) * perPage],
-                page_num = p + 1,
-                page_count = npages,
             ))
     return pages
 
@@ -1118,26 +1111,6 @@ def wide_header(comp_label, date_text, text_color):
         ),
         render.Box(width = W_W, height = 1, color = W_HDR_RULE),
     ])
-
-def with_page_dots(frame, pg):
-    # One dot per page across the whole rotation, centered along the bottom; the
-    # current page is lit white, the rest dim. Only shown when there's >1 page.
-    total = pg["overall_total"]
-    if total <= 1:
-        return frame
-    dots = []
-    for i in range(total):
-        if i > 0:
-            dots.append(render.Box(width = 2, height = 1))
-        dots.append(render.Circle(color = W_WHITE if i == pg["overall_index"] else "#3a3f4a", diameter = 2))
-    cw = total * 2 + (total - 1) * 2 + 4
-    chip = render.Box(width = cw, height = 5, color = "#000a", child = render.Padding(pad = (2, 1, 2, 1), child = render.Row(cross_align = "center", children = dots)))
-    overlay = render.Box(
-        width = W_W,
-        height = W_H,
-        child = render.Column(expanded = True, main_align = "end", cross_align = "center", children = [chip]),
-    )
-    return render.Stack(children = [frame, overlay])
 
 def wide_needs_2x():
     # 1x devices can't fit the wide layouts; explain rather than render garbage.
@@ -1174,8 +1147,7 @@ def wide3_page(pg, comp_label, header_color, colors_on):
         height = W_H - W_HEADER_H,
         child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = rows),
     )
-    frame = render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
-    return with_page_dots(frame, pg)
+    return render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
 
 def wide3_row(g, colors_on):
     left = g["left"]
@@ -1276,8 +1248,7 @@ def wide6_page(pg, comp_label, header_color, colors_on):
         height = body_h,
         child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = row_widgets),
     )
-    frame = render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
-    return with_page_dots(frame, pg)
+    return render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
 
 def wide6_cell(g, colors_on, w, h):
     left = g["left"]
@@ -1366,8 +1337,7 @@ def wide4_page(pg, comp_label, header_color, colors_on):
         height = body_h,
         child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = row_widgets),
     )
-    frame = render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
-    return with_page_dots(frame, pg)
+    return render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
 
 def wide4_cell(g, colors_on, w, h):
     left = g["left"]

--- a/apps/soccerwomens/manifest.yaml
+++ b/apps/soccerwomens/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - real-time
   - soccer
 published: '2023-01-03T17:29:27Z'
-updated: '2026-06-17T20:24:35Z'
+updated: '2026-06-17T20:59:26Z'

--- a/apps/soccerwomens/manifest.yaml
+++ b/apps/soccerwomens/manifest.yaml
@@ -7,6 +7,7 @@ author: jvivona
 fileName: soccerwomens.star
 packageName: soccerwomens
 recommendedInterval: 5
+supports2x: true
 category: sports
 tags:
   - real-time

--- a/apps/soccerwomens/manifest.yaml
+++ b/apps/soccerwomens/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - real-time
   - soccer
 published: '2023-01-03T17:29:27Z'
-updated: '2025-12-02T19:30:22Z'
+updated: '2026-06-17T20:24:35Z'

--- a/apps/soccerwomens/soccerwomens.star
+++ b/apps/soccerwomens/soccerwomens.star
@@ -14,7 +14,7 @@ Author: jvivona
 
 load("encoding/json.star", "json")
 load("http.star", "http")
-load("render.star", "render")
+load("render.star", "canvas", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
@@ -53,6 +53,53 @@ SHORTENED_WORDS = """
 }
 """
 
+# ============================================================================
+# Wide 2x layouts (display options "Wide 3" and "Wide 4")
+# Designed for the native 128x64 canvas. See design handoff README.
+# All sizes are in LED units (the real grid), not the mock's px.
+# ============================================================================
+
+# State / accent tokens (from the design handoff)
+W_BG = "#000000"  # pure black (LED off)
+W_WIN = "#ffe14d"  # winner text (yellow)
+W_WHITE = "#ffffff"  # loser / neutral text
+W_LIVE = "#2ee65f"  # in-progress (green)
+W_HALF = "#ffb02e"  # half-time (amber)
+W_FINAL = "#7f8794"  # final / muted label (grey)
+W_REC = "#8a93a3"  # W-D-L record muted on black
+W_DASH = "#5b6470"  # score dash
+W_HDR_BG = "#11151f"  # header bg (a hair lighter than black)
+W_HDR_RULE = "#232a38"  # header bottom rule
+W_STEEL = "#444b57"  # fallback for near-black team colors
+
+# Game box when the colors toggle is OFF, so games read as separate boxes (split
+# by the black gridlines) instead of blending into one black field.
+W_OFF_BG = "#262b33"
+W_TEAM_ALPHA = "80"  # alpha on team-color bands so they read softer over black (~50%)
+
+# Fonts (bitmap, real sizes). Hero numerals re-derived to fit the 18-LED row:
+# terminus-16 + an 8-LED status will not co-exist in one row, so the hero score
+# uses 6x13 and the status uses tom-thumb. See README "Fidelity" note.
+W_FONT_HEADER = "tb-8"
+W_FONT_CODE = "tb-8"
+W_FONT_REC = "tb-8"
+W_FONT_SCORE = "6x10"  # hero score / kickoff in Wide 3 (was 6x13 — toned down)
+W3_STATUS_FONT = "CG-pixel-3x5-mono"  # Wide 3 status line (5 LED, fits under 6x13)
+W_FONT_STATUS = "tom-thumb"  # Wide 3/4 status chips / records
+W_FONT_CELL = "tb-8"  # code + score in Wide 4 cells
+
+# Geometry (LED units)
+W_W = 128
+W_H = 64
+W_HEADER_H = 8  # 7 bg + 1 rule (all-caps day header has no descenders)
+
+# Narrow center score column in Wide 3, to widen the team zones so a two-digit
+# W-D-L record ("20-8-10") clears the center.
+W3_CENTER_W = 26
+W3_ROW_H = 18  # 3 rows * 18 + 2 * 1 divider == 56 body, exact
+W3_FLAG = 16  # flag/crest in Wide 3 zone
+W4_FLAG = 9  # flag/crest in Wide 4 cell line
+
 def main(config):
     LEAGUE_ABBR = json.decode(http.get(url = ABBR_URL, ttl_seconds = COMPS_TTL).body())
     renderCategory = []
@@ -75,12 +122,17 @@ def main(config):
         fwd_time = now + time.parse_duration("%dh" % (6 * 24))
         date_range_search = "?dates=%s-%s" % (back_time.format("20060102"), (fwd_time.format("20060102")))
 
-    league = {API: API + selectedLeague + "/scoreboard" + date_range_search}
+    scoreboard_url = API + selectedLeague + "/scoreboard" + date_range_search
+    league = {API: scoreboard_url}
 
     scores = get_scores(league)
 
     if len(scores) > 0:
         displayType = config.get("displayType", "colors")
+
+        # New 2x wide styles take a completely separate render path.
+        if displayType == "wide3" or displayType == "wide4":
+            return render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_url)
 
         #logoType = config.get("logoType", "primary")
         timeColor = config.get("displayTimeColor", "#FFF")
@@ -455,16 +507,31 @@ def main(config):
                     ],
                 )
 
+        anim = render.Animation(children = renderCategory)
+
+        # `supports2x: true` makes the server hand every style a 128x64 canvas.
+        # The legacy 64x32 styles aren't responsive, so on a wide canvas pin them
+        # to a crisp, centered 64x32 island instead of rendering broken top-left.
+        # (Wide 3/4 are the native 2x styles and use the full canvas.)
+        if canvas.is2x() or canvas.width() > 64:
+            root_child = render.Box(
+                width = canvas.width(),
+                height = canvas.height(),
+                color = "#000000",
+                child = render.Column(
+                    expanded = True,
+                    main_align = "center",
+                    cross_align = "center",
+                    children = [render.Box(width = 64, height = 32, child = anim)],
+                ),
+            )
+        else:
+            root_child = render.Column(children = [anim])
+
         return render.Root(
             delay = rotationSpeed,
             show_full_animation = True,
-            child = render.Column(
-                children = [
-                    render.Animation(
-                        children = renderCategory,
-                    ),
-                ],
-            ),
+            child = root_child,
         )
     else:
         return []
@@ -485,6 +552,14 @@ displayOptions = [
     schema.Option(
         display = "Retro",
         value = "retro",
+    ),
+    schema.Option(
+        display = "Wide · 3 Games (2x)",
+        value = "wide3",
+    ),
+    schema.Option(
+        display = "Wide · 4 Games (2x)",
+        value = "wide4",
     ),
 ]
 
@@ -595,6 +670,11 @@ def get_schema():
                 default = displayOptions[0].value,
                 options = displayOptions,
             ),
+            schema.Generated(
+                id = "wide_generated",
+                source = "displayType",
+                handler = show_wide_options,
+            ),
             schema.Color(
                 id = "displayTimeColor",
                 name = "Time Color",
@@ -638,6 +718,21 @@ def get_schema():
             ),
         ],
     )
+
+def show_wide_options(displayType):
+    # Team-colors background toggle only applies to the wide 2x styles.
+    if displayType == "wide3" or displayType == "wide4":
+        return [
+            schema.Toggle(
+                id = "wide_team_colors",
+                name = "Team color backgrounds",
+                desc = "Tint each team's area with its team color (off = black bands).",
+                icon = "palette",
+                default = True,
+            ),
+        ]
+    else:
+        return []
 
 def show_day_range(day_range):
     # need to do the string comparison here to make it consistent instead of converting to bool - its a whole thing
@@ -764,3 +859,457 @@ def get_cachable_data(url):
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
 
     return res.body()
+
+# ============================================================================
+# Wide 2x layouts — render path
+# ============================================================================
+
+def render_wide(config, scores, displayType, timezone, leagueAbbr, scoreboard_url):
+    # These layouts need the native 128x64 (2x) canvas. The device signals 2x via
+    # canvas.is2x() (requires `supports2x: true` in manifest.yaml, or the server
+    # renders 1x); CLI `-w 128 -t 64` reports width 128 but not is2x. Accept
+    # either so it works on real wide hardware and in local render tests.
+    if not (canvas.is2x() or canvas.width() >= W_W):
+        return wide_needs_2x()
+
+    perPage = {"wide3": 3, "wide4": 4}[displayType]
+    colors_on = config.bool("wide_team_colors", True)
+    rotationSpeed = int(config.get("displaySpeed", DEFAULT_DISPLAY_SPEED))
+    comp_label = get_comp_label(scoreboard_url, leagueAbbr)
+
+    # Header (competition + date) color, so back-to-back apps can be tinted apart.
+    header_color = config.get("displayTimeColor", "#FFF")
+
+    games = []
+    for s in scores:
+        g = parse_game_wide(s, config, timezone)
+        if g != None:
+            games.append(g)
+
+    pages = build_pages(games, perPage)
+    if len(pages) == 0:
+        return []
+
+    frames = []
+    for pg in pages:
+        if displayType == "wide3":
+            frames.append(wide3_page(pg, comp_label, header_color, colors_on))
+        else:
+            frames.append(wide4_page(pg, comp_label, header_color, colors_on))
+
+    # Each page is one static frame; the per-frame delay is the rotation timer,
+    # so every page in the window shows at least once per loop.
+    return render.Root(
+        delay = rotationSpeed,
+        show_full_animation = True,
+        child = render.Column(children = [render.Animation(children = frames)]),
+    )
+
+def get_comp_label(scoreboard_url, leagueAbbr):
+    # Cache-hit reuse of the scoreboard fetch just to read the competition name
+    # (leagues[0].abbreviation, e.g. "FIFA World Cup") for the header. Works for
+    # every league/tournament the app offers; falls back to the short league code.
+    data = json.decode(get_cachable_data(scoreboard_url))
+    leagues = data.get("leagues", [])
+    if len(leagues) > 0:
+        abbr = leagues[0].get("abbreviation", "")
+        if abbr != "":
+            return abbr
+    return leagueAbbr
+
+def parse_game_wide(s, config, timezone):
+    comp = s["competitions"][0]
+    competitors = comp["competitors"]
+    if len(competitors) < 2:
+        return None
+
+    state = s["status"]["type"]["state"]
+    type_name = s["status"]["type"].get("name", "")
+    short_detail = s["status"]["type"].get("shortDetail", "")
+
+    # local date for day grouping + header (short, no weekday)
+    dt = time.parse_time(s["date"], format = "2006-01-02T15:04Z").in_location(timezone)
+    day_key = dt.format("20060102")
+    if config.bool("is_us_date_format", False):
+        date_text = dt.format("1/2")  # e.g. "6/17"
+    else:
+        date_text = dt.format("2 Jan")  # e.g. "17 Jun"
+
+    home = wide_side(competitors[0])
+    away = wide_side(competitors[1])
+
+    # penalty shootout: scores present while pens are live AND after (FINAL_PEN).
+    # The regulation score stays in the score slot; the tally goes in the status
+    # ("PK 4-2" live / "FT 4-2" final) since 0(4)-0(2) won't fit the narrow center.
+    hp = competitors[0].get("shootoutScore", "0")
+    ap = competitors[1].get("shootoutScore", "0")
+    pen_final = type_name == "STATUS_FINAL_PEN"
+    pen_live = state == "in" and (hp != "0" or ap != "0")
+
+    # winner (post only) — shown by yellow text, never a swapped background
+    home_win = False
+    away_win = False
+    if state == "post" and type_name != "STATUS_POSTPONED":
+        if pen_final:
+            home_win = int_or(hp) > int_or(ap)
+            away_win = int_or(ap) > int_or(hp)
+        else:
+            home_win = int_or(home["score"]) > int_or(away["score"])
+            away_win = int_or(away["score"]) > int_or(home["score"])
+
+    # status text + color + kickoff
+    is_live = False
+    kickoff = ""
+    if state == "pre":
+        kickoff = wide_kickoff(s["date"], config, timezone)
+        status_text = ""
+        status_color = W_FINAL
+    elif state == "in":
+        up = short_detail.upper()
+        if pen_live:
+            status_text = "PENS"  # live shootout; a tally here would be stale, omit it
+            status_color = W_LIVE
+            is_live = True
+        elif up.startswith("HT") or up.find("HALF") >= 0:
+            status_text = "HT"
+            status_color = W_HALF
+        else:
+            status_text = short_detail.strip()[:6]
+            status_color = W_LIVE
+            is_live = True
+    elif type_name == "STATUS_POSTPONED":
+        status_text = "PPD"
+        status_color = W_FINAL
+        home["score"] = ""
+        away["score"] = ""
+    else:  # post
+        status_text = "FT"
+        status_color = W_FINAL
+
+    home["code_color"] = W_WIN if home_win else W_WHITE
+    away["code_color"] = W_WIN if away_win else W_WHITE
+    home["score_color"] = W_WIN if home_win else W_WHITE
+    away["score_color"] = W_WIN if away_win else W_WHITE
+
+    # team_sequence: which team sits on the left (home zone)
+    if config.get("team_sequence", DEFAULT_TEAM_DISPLAY) == "home":
+        left, right = home, away
+        lp, rp = hp, ap
+    else:
+        left, right = away, home
+        lp, rp = ap, hp
+
+    # final shootout: append the tally (display order) -> "FT 4-2". Live shootouts
+    # stay just "PENS" (the running tally would be stale between refreshes).
+    has_pen = pen_final
+    if pen_final:
+        status_text = status_text + " " + lp + "-" + rp
+
+    return dict(
+        state = state,
+        is_live = is_live,
+        status_text = status_text,
+        status_color = status_color,
+        kickoff = kickoff,
+        has_pen = has_pen,
+        day_key = day_key,
+        date_text = date_text,
+        left = left,
+        right = right,
+    )
+
+def wide_side(competitor):
+    team = competitor["team"]
+    name = team.get("name", "")
+    code = team.get("abbreviation", name[0:3].upper() if name != "" else "?")
+    logo_url = team.get("logo", "") or MISSING_LOGO
+    score = competitor.get("score", "")
+    record = ""
+    recs = competitor.get("records", None)
+    if recs != None and len(recs) > 0:
+        record = recs[0].get("summary", "")
+    return dict(
+        code = code[:3],
+        color = wide_team_color(team.get("color", "")),
+        logo = get_logoType(logo_url),
+        score = score,
+        record = record,
+        code_color = W_WHITE,
+        score_color = W_WHITE,
+    )
+
+def int_or(v):
+    if v != None and str(v).isdigit():
+        return int(v)
+    return 0
+
+def wide_kickoff(date_str, config, timezone):
+    t = time.parse_time(date_str, format = "2006-01-02T15:04Z").in_location(timezone)
+    if config.bool("is_24_hour_format", False):
+        return t.format("15:04")
+    return t.format("3:04PM")[:-1]  # strip trailing M -> "3:04P"
+
+HEX = "0123456789abcdef"
+
+def hex2(n):
+    # Starlark's % formatting has no width/zero-pad, so build hex bytes by hand.
+    if n < 0:
+        n = 0
+    if n > 255:
+        n = 255
+    return HEX[n // 16] + HEX[n % 16]
+
+def wide_team_color(hexcolor):
+    # Returned with an alpha suffix so the band softens against the black panel
+    # (same idea as the legacy "colors" style's 77 alpha), keeping white/yellow
+    # text readable.
+    h = hexcolor.replace("#", "")
+    if len(h) != 6:
+        return W_STEEL + W_TEAM_ALPHA
+    r = int(h[0:2], 16)
+    g = int(h[2:4], 16)
+    b = int(h[4:6], 16)
+    lum = (299 * r + 587 * g + 114 * b) // 1000
+
+    # near-black is invisible on a black panel -> steel
+    if lum < 55:
+        return W_STEEL + W_TEAM_ALPHA
+
+    # too light/bright kills white & yellow text -> scale down to a mid lum
+    if lum > 125:
+        r = (r * 125) // lum
+        g = (g * 125) // lum
+        b = (b * 125) // lum
+    return "#" + hex2(r) + hex2(g) + hex2(b) + W_TEAM_ALPHA
+
+def build_pages(games, perPage):
+    # Group by local day in feed (kickoff) order, chunk each day into pages of
+    # perPage, skip empty days, flatten day-by-day, page-by-page.
+    order = []
+    bucket = {}
+    for g in games:
+        k = g["day_key"]
+        if k not in bucket:
+            bucket[k] = []
+            order.append(k)
+        bucket[k].append(g)
+
+    pages = []
+    for k in order:
+        dgames = bucket[k]
+        npages = (len(dgames) + perPage - 1) // perPage
+        for p in range(npages):
+            pages.append(dict(
+                date_text = dgames[0]["date_text"],
+                games = dgames[p * perPage:(p + 1) * perPage],
+            ))
+    return pages
+
+# ---- shared chrome ---------------------------------------------------------
+
+def wide_header(comp_label, date_text, text_color):
+    # Competition (what you're looking at) on the left, short date on the right.
+    # Both take the user's "Time Color" so back-to-back apps can be tinted apart.
+    return render.Column(children = [
+        render.Box(
+            width = W_W,
+            height = W_HEADER_H - 1,
+            color = W_HDR_BG,
+            child = render.Row(
+                expanded = True,
+                main_align = "space_between",
+                cross_align = "center",
+                children = [
+                    render.Padding(pad = (2, 0, 0, 0), child = render.Text(content = comp_label, font = W_FONT_HEADER, color = text_color)),
+                    render.Padding(pad = (0, 0, 2, 0), child = render.Text(content = date_text, font = W_FONT_HEADER, color = text_color)),
+                ],
+            ),
+        ),
+        render.Box(width = W_W, height = 1, color = W_HDR_RULE),
+    ])
+
+def wide_needs_2x():
+    # 1x devices can't fit the wide layouts; explain rather than render garbage.
+    return render.Root(
+        child = render.Box(
+            width = 64,
+            height = 32,
+            color = W_BG,
+            child = render.Column(
+                expanded = True,
+                main_align = "center",
+                cross_align = "center",
+                children = [
+                    render.Text(content = "WIDE VIEW", font = "tb-8", color = W_WIN),
+                    render.Box(width = 1, height = 1),
+                    render.Text(content = "needs a 2x", font = "tom-thumb", color = W_WHITE),
+                    render.Text(content = "display", font = "tom-thumb", color = W_WHITE),
+                ],
+            ),
+        ),
+    )
+
+# ---- Wide 3 ----------------------------------------------------------------
+
+def wide3_page(pg, comp_label, header_color, colors_on):
+    games = pg["games"]
+    rows = []
+    for i in range(len(games)):
+        if i > 0:
+            rows.append(render.Box(width = W_W, height = 1, color = W_BG))
+        rows.append(wide3_row(games[i], colors_on))
+    body = render.Box(
+        width = W_W,
+        height = W_H - W_HEADER_H,
+        child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = rows),
+    )
+    return render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
+
+def wide3_row(g, colors_on):
+    left = g["left"]
+    right = g["right"]
+    lcolor = left["color"] if colors_on else W_OFF_BG
+    rcolor = right["color"] if colors_on else W_OFF_BG
+    zone_w = (W_W - W3_CENTER_W) // 2  # 47
+    return render.Row(
+        expanded = True,
+        cross_align = "center",
+        children = [
+            wide3_zone(left, lcolor, "left", zone_w),
+            wide3_center(g),
+            wide3_zone(right, rcolor, "right", zone_w),
+        ],
+    )
+
+def wide3_zone(side, bg, side_name, w):
+    flag = render.Image(src = side["logo"], width = W3_FLAG, height = W3_FLAG)
+    show_rec = side["record"] != ""
+
+    # W-D-L record sits on its own line under the code (the zone can't fit
+    # flag+code+record side by side). Shown for every state — the game's score or
+    # kickoff lives in the center column.
+    if show_rec:
+        idblock = render.Column(
+            cross_align = "start" if side_name == "left" else "end",
+            children = [
+                render.Text(content = side["code"], font = W_FONT_CODE, color = side["code_color"]),
+                render.Text(content = side["record"], font = W_FONT_STATUS, color = W_WHITE),
+            ],
+        )
+    else:
+        idblock = render.Text(content = side["code"], font = W_FONT_CODE, color = side["code_color"])
+
+    if side_name == "left":
+        inner = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [flag, render.Box(width = 4, height = 1), idblock])
+        pad = (2, 0, 0, 0)
+    else:
+        inner = render.Row(expanded = True, main_align = "end", cross_align = "center", children = [idblock, render.Box(width = 4, height = 1), flag])
+        pad = (0, 0, 2, 0)
+
+    return render.Box(width = w, height = W3_ROW_H, color = bg, child = render.Padding(pad = pad, child = inner))
+
+def wide3_center(g):
+    if g["state"] == "pre":
+        # tb-8 (not the hero 6x10) so a 6-char kickoff like "12:00A" fits the
+        # narrow center column.
+        kids = [render.Text(content = g["kickoff"], font = W_FONT_HEADER, color = W_WHITE)]
+    else:
+        score_row = render.Row(cross_align = "center", children = [
+            render.Text(content = g["left"]["score"], font = W_FONT_SCORE, color = g["left"]["score_color"]),
+            render.Box(width = 2, height = 1),
+            render.Text(content = "-", font = W_FONT_SCORE, color = W_DASH),
+            render.Box(width = 2, height = 1),
+            render.Text(content = g["right"]["score"], font = W_FONT_SCORE, color = g["right"]["score_color"]),
+        ])
+
+        # The time already renders green for a live match, so it carries the
+        # in-progress signal on its own — no separate pulse dot needed.
+        status = render.Text(content = g["status_text"], font = W3_STATUS_FONT, color = g["status_color"])
+        kids = [score_row, status]
+    return render.Box(
+        width = W3_CENTER_W,
+        height = W3_ROW_H,
+        color = W_BG,
+        child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = kids),
+    )
+
+# ---- Wide 4 ----------------------------------------------------------------
+# A 2x2 grid. The cells (~63 wide) are roomy enough to keep the flag, code,
+# score/record AND a status line (FT/HT/clock/kickoff) below each game.
+
+def wide4_page(pg, comp_label, header_color, colors_on):
+    games = pg["games"]
+    n = len(games)
+    cols = 2
+    grid_rows = [games[r:r + cols] for r in range(0, n, cols)]
+    cell_w = (W_W - (cols - 1)) // cols  # 63, black gridlines between cells
+    body_h = W_H - W_HEADER_H  # 56
+    cell_h = (body_h - 1) // 2  # 27
+
+    row_widgets = []
+    for ri in range(len(grid_rows)):
+        if ri > 0:
+            row_widgets.append(render.Box(width = W_W, height = 1, color = W_BG))
+        cells = []
+        for ci in range(len(grid_rows[ri])):
+            if ci > 0:
+                cells.append(render.Box(width = 1, height = cell_h, color = W_BG))
+            cells.append(wide4_cell(grid_rows[ri][ci], colors_on, cell_w, cell_h))
+        row_widgets.append(render.Row(main_align = "center", cross_align = "center", children = cells))
+
+    body = render.Box(
+        width = W_W,
+        height = body_h,
+        child = render.Column(expanded = True, main_align = "center", cross_align = "center", children = row_widgets),
+    )
+    return render.Column(children = [wide_header(comp_label, pg["date_text"], header_color), body])
+
+def wide4_cell(g, colors_on, w, h):
+    left = g["left"]
+    right = g["right"]
+    lc = left["color"] if colors_on else W_OFF_BG
+    rc = right["color"] if colors_on else W_OFF_BG
+    status_h = 7
+    line_h = (h - status_h) // 2
+    return render.Column(children = [
+        wide4_line(g, left, lc, line_h, w),
+        wide4_line(g, right, rc, h - status_h - line_h, w),
+        wide4_status(g, w, status_h),
+    ])
+
+def wide4_line(g, side, bg, lh, w):
+    flag = render.Image(src = side["logo"], width = W4_FLAG, height = W4_FLAG)
+    code = render.Text(content = side["code"], font = W_FONT_CELL, color = side["code_color"])
+    if g["state"] == "pre":
+        rightval = render.Text(content = side["record"], font = W_FONT_STATUS, color = W_WHITE)
+    else:
+        rightval = render.Text(content = side["score"], font = W_FONT_CELL, color = side["score_color"])
+    return render.Box(
+        width = w,
+        height = lh,
+        color = bg,
+        child = render.Padding(pad = (2, 0, 2, 0), child = render.Row(
+            expanded = True,
+            main_align = "space_between",
+            cross_align = "center",
+            children = [
+                render.Row(cross_align = "center", children = [flag, render.Box(width = 3, height = 1), code]),
+                rightval,
+            ],
+        )),
+    )
+
+def wide4_status(g, w, h):
+    # Black status footer with the game time/state centered: kickoff (upcoming),
+    # clock (live, green), HT (amber) or FT (grey). A live match already reads as
+    # in-progress from the green clock, so there's no separate pulse dot.
+    if g["state"] == "pre":
+        kids = [render.Text(content = g["kickoff"], font = W_FONT_STATUS, color = W_WHITE)]
+    else:
+        kids = [render.Text(content = g["status_text"], font = W_FONT_STATUS, color = g["status_color"])]
+    return render.Box(
+        width = w,
+        height = h,
+        color = W_BG,
+        child = render.Row(expanded = True, main_align = "center", cross_align = "center", children = kids),
+    )

--- a/apps/soccerwomens/soccerwomens.star
+++ b/apps/soccerwomens/soccerwomens.star
@@ -910,11 +910,11 @@ def get_comp_label(scoreboard_url, leagueAbbr):
     # (leagues[0].abbreviation, e.g. "FIFA World Cup") for the header. Works for
     # every league/tournament the app offers; falls back to the short league code.
     data = json.decode(get_cachable_data(scoreboard_url))
-    leagues = data.get("leagues", [])
+    leagues = data.get("leagues") or []
     if len(leagues) > 0:
-        abbr = leagues[0].get("abbreviation", "")
-        if abbr != "":
-            return abbr
+        abbr = leagues[0].get("abbreviation")
+        if abbr:
+            return str(abbr)
     return leagueAbbr
 
 def parse_game_wide(s, config, timezone):
@@ -924,8 +924,8 @@ def parse_game_wide(s, config, timezone):
         return None
 
     state = s["status"]["type"]["state"]
-    type_name = s["status"]["type"].get("name", "")
-    short_detail = s["status"]["type"].get("shortDetail", "")
+    type_name = s["status"]["type"].get("name") or ""
+    short_detail = s["status"]["type"].get("shortDetail") or ""
 
     # local date for day grouping + header (short, no weekday)
     dt = time.parse_time(s["date"], format = "2006-01-02T15:04Z").in_location(timezone)
@@ -941,8 +941,8 @@ def parse_game_wide(s, config, timezone):
     # penalty shootout: scores present while pens are live AND after (FINAL_PEN).
     # The regulation score stays in the score slot; the tally goes in the status
     # ("PK 4-2" live / "FT 4-2" final) since 0(4)-0(2) won't fit the narrow center.
-    hp = competitors[0].get("shootoutScore", "0")
-    ap = competitors[1].get("shootoutScore", "0")
+    hp = competitors[0].get("shootoutScore") or "0"
+    ap = competitors[1].get("shootoutScore") or "0"
     pen_final = type_name == "STATUS_FINAL_PEN"
     pen_live = state == "in" and (hp != "0" or ap != "0")
 
@@ -1019,18 +1019,20 @@ def parse_game_wide(s, config, timezone):
     )
 
 def wide_side(competitor):
-    team = competitor["team"]
-    name = team.get("name", "")
-    code = team.get("abbreviation", name[0:3].upper() if name != "" else "?")
-    logo_url = team.get("logo", "") or MISSING_LOGO
-    score = competitor.get("score", "")
+    team = competitor.get("team") or {}
+    name = team.get("name") or ""
+    code = team.get("abbreviation") or (name[0:3].upper() if name else "?")
+    logo_url = team.get("logo") or MISSING_LOGO
+    score_val = competitor.get("score")
+    score = str(score_val) if score_val != None else ""
     record = ""
-    recs = competitor.get("records", None)
-    if recs != None and len(recs) > 0:
-        record = recs[0].get("summary", "")
+    recs = competitor.get("records")
+    if recs and len(recs) > 0:
+        summary = recs[0].get("summary")
+        record = str(summary) if summary != None else ""
     return dict(
         code = code[:3],
-        color = wide_team_color(team.get("color", "")),
+        color = wide_team_color(team.get("color")),
         logo = get_logoType(logo_url),
         score = score,
         record = record,
@@ -1063,6 +1065,8 @@ def wide_team_color(hexcolor):
     # Returned with an alpha suffix so the band softens against the black panel
     # (same idea as the legacy "colors" style's 77 alpha), keeping white/yellow
     # text readable.
+    if not hexcolor:
+        return W_STEEL + W_TEAM_ALPHA
     h = hexcolor.replace("#", "")
     if len(h) != 6:
         return W_STEEL + W_TEAM_ALPHA


### PR DESCRIPTION
## What

Adds two native-2x display styles — **Wide · 3 Games** and **Wide · 4 Games** — to both **Mens Soccer** (`soccermens`) and **Womens Soccer** (`soccerwomens`). These render on the full 128×64 canvas and show several matches at once, which the existing one-game-at-a-time styles can't.

Both apps now declare `supports2x: true`.

## Styles

- **Wide · 3 Games** — three full-width rows: crest + code + W-D-L record per side, with the score / kickoff / status in a center column.
- **Wide · 4 Games** — a 2×2 grid of compact cells (crest, code, score/record) with a status footer (kickoff / live clock / HT / FT) under each game.

Shared behavior:
- Competition-forward header (e.g. "Women's Super League") with the date, tintable via the existing **Time Color** setting.
- **Team color backgrounds** toggle (on by default) — softened team-color bands, or neutral boxes when off.
- W-D-L records on upcoming games; yellow winner highlighting on finished games.
- Penalty-shootout handling (`PENS` live, `FT 4-2` final).
- A live match is signaled by the green clock alone — no separate pulse dot.

Legacy styles (Team Colors / Black / Horizontal / Retro) are unaffected: on a wide canvas they're pinned to a centered 64×32 island so enabling 2x doesn't break them. 1x devices that pick a wide style get a short "needs a 2x display" notice instead of a broken render.

## Testing

- `pixlet format`, `pixlet lint`, and `pixlet check` pass for both apps.
- Rendered at 2x against live, finished, and upcoming fixtures (World Cup, Women's Super League, NWSL) covering live clock, HT, FT, kickoff, penalty, and odd-count-page cases.
- Verified legacy styles still render correctly at both 1x and 2x.

## Notes

Draft — the two apps intentionally share the wide-layout code (mirroring how these sister apps already duplicate their legacy render paths); happy to factor it out if preferred.
