### PR TITLE
Set checkiday app status to broken with reason

### DIFF
--- a/apps/checkiday/manifest.yaml
+++ b/apps/checkiday/manifest.yaml
@@ -12,6 +12,6 @@ tags:
   - productivity
   - news
 published: '2023-10-12T16:13:03Z'
-updated: '2025-12-05T22:28:51Z'
+updated: '2026-07-08T05:37:15Z'
 broken: true
 brokenReason: API endpoint changed and requires user api key

--- a/apps/checkiday/manifest.yaml
+++ b/apps/checkiday/manifest.yaml
@@ -13,3 +13,5 @@ tags:
   - news
 published: '2023-10-12T16:13:03Z'
 updated: '2025-12-05T22:28:51Z'
+broken: true
+brokenReason: API endpoint changed and requires user api key


### PR DESCRIPTION
Mark the app as broken due to API changes requiring a user API key.