### PR TITLE
nationalday: center short lists that don't scroll

### DIFF
--- a/apps/nationalday/manifest.yaml
+++ b/apps/nationalday/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - lifestyle
   - holiday
 published: '2024-12-07T18:59:35Z'
-updated: '2026-06-17T20:47:04Z'
+updated: '2026-07-09T11:26:08Z'

--- a/apps/nationalday/nationalday.star
+++ b/apps/nationalday/nationalday.star
@@ -12,7 +12,7 @@ load("render.star", "canvas", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 24315
+VERSION = 24316
 
 # 2x (128x64) uses the wider canvas and a larger font; 1x is unchanged.
 IS2X = canvas.is2x()
@@ -106,6 +106,9 @@ def main(config):
                         height = ARTICLE_AREA_HEIGHT,
                         scroll_direction = "vertical",
                         offset_start = ARTICLE_AREA_HEIGHT,
+                        # only takes effect on short lists that fit without
+                        # scrolling; the marquee ignores it once it scrolls
+                        align = "center",
                         child =
                             render.Column(
                                 main_align = "space_between",
@@ -182,8 +185,12 @@ def displayItem(json_data):
     item = []
 
     for i in range(len(json_data)):
+        # spacer goes between items, never after the last one: a trailing
+        # spacer is measured as part of the column and would push a centered
+        # short list up by half its height
+        if i > 0:
+            item.append(render.Box(width = FULL_WIDTH, height = SPACER_HEIGHT, color = SPACER_COLOR))
         item.append(render.WrappedText(json_data[i], font = ARTICLE_SUB_TITLE_FONT, color = ARTICLE_SUB_TITLE_COLOR[i % 2], align = "center"))
-        item.append(render.Box(width = FULL_WIDTH, height = SPACER_HEIGHT, color = SPACER_COLOR))
 
     return item
 


### PR DESCRIPTION
## Problem

The article area of National Day is a vertical `render.Marquee`. When the day's list is short enough to fit (1–4 items, depending on wrapping and 1x vs 2x), the marquee doesn't scroll — and on that path it pins the child at `offset = 0`. The result is text flush against the title bar with a block of dead space underneath.

## Fix

Pass `align = "center"` to the marquee. It only consults `Align` inside the `cw <= size` branch of `Marquee.Paint`, so this is inert whenever the content actually scrolls.

Second, `displayItem()` appended a spacer after *every* item, including the last. That trailing spacer is measured as part of the column the marquee centers, so `align` alone still left the text high by `SPACER_HEIGHT / 2`. Emitting the spacer only *between* items makes the gaps exactly symmetric. Its only other effect was a few all-black tail frames on the scroll, which libwebp coalesced anyway.

## Verification

Rendered against the live feed on pixlet v0.52.0, at 1x and 2x:

| mode | items | before | after |
|---|---|---|---|
| day | 2 | static, gaps 0/8 | static, gaps **4/4** |
| week | 1 | static, gaps 0/19 | static, gaps **9/10** |
| month | 17 | scrolls, 268 frames | scrolls, 268 frames |

"gaps" = pixel rows of empty space above/below the text block inside the article area.

For the scrolling case I decoded all 268 frames of the month feed at both resolutions and diffed them: **every frame is pixel-identical** to the pre-change render. The loop is 400 ms shorter (27300 → 26900 ms), which is the four black tail frames the trailing spacer used to contribute.

Confirmed on real hardware at 1x and 2x.

`pixlet format` / `lint` / `check` all clean. Previews aren't regenerated: they were rendered on a day when the feed was long enough to scroll, and the scrolling path is unchanged, so they remain accurate — regenerating today would just swap in a static 2-item still.

🤖 Generated with [Claude Code](https://claude.com/claude-code)