### PR TITLE
flightsnearby_adsb: optional Logostream API key for tail logos beyond built-in list

### DIFF
--- a/apps/flightsnearby_adsb/README.md
+++ b/apps/flightsnearby_adsb/README.md
@@ -17,6 +17,7 @@ This app was forked from [flightsnearby](flightsnearby) and uses [adsb.lol](http
 *   Distance - radius from location to look for flights.
 *   Hide - whether to hide (not display) this app if no flights are nearby.
 *   Extend - whether to show detailed info about the flight.
+*   Logostream API Key (optional) - fetches a tail logo for airlines outside the ~30 built into this app. Get one at https://airline.logostream.dev/pricing. Airline logos provided by [Logostream](https://airline.logostream.dev/). Without a key, the app falls back to its built-in tail images.
 
 ## Screenshot
 ![](flightsnearby_adsb.gif)

--- a/apps/flightsnearby_adsb/flightsnearby_adsb.star
+++ b/apps/flightsnearby_adsb/flightsnearby_adsb.star
@@ -44,6 +44,19 @@ TAILS = {
 }
 DEFAULT_TAIL = TAILS["ELE"]
 
+def get_tail_image(airline_code, logostream_api_key):
+    tail = TAILS.get(airline_code)
+    if tail != None:
+        return tail
+
+    if logostream_api_key:
+        logostream_url = "https://airlines-api.logostream.dev/airlines/icao/%s?key=%s&variant=tail" % (airline_code, logostream_api_key)
+        res = http.get(logostream_url, ttl_seconds = 86400)
+        if res.status_code == 200:
+            return res.body()
+
+    return DEFAULT_TAIL
+
 CFG_DEFAULT_LOCATION = json.encode({
     "lat": "37.5630",
     "lng": "-122.3255",
@@ -106,6 +119,13 @@ def get_schema():
                 desc = "Show extended data for nearest flight?",
                 icon = "gear",
                 default = CFG_DEFAULT_EXTEND,
+            ),
+            schema.Text(
+                id = "logostream_api_key",
+                name = "Logostream API Key",
+                icon = "key",
+                desc = "Optional API Key from logostream.dev to fetch tail logos for airlines not in the built-in list. Get one at https://airline.logostream.dev/pricing",
+                secret = True,
             ),
         ],
     )
@@ -302,6 +322,7 @@ def main(config):
     distance = int(config.get("distance", CFG_DEFAULT_DISTANCE))
     hide_when_nothing_to_display = config.bool("hide", CFG_DEFAULT_HIDE_IF_NONE)
     extend = config.bool("extend", CFG_DEFAULT_EXTEND)
+    logostream_api_key = config.get("logostream_api_key")
 
     print("Showing flights near lat: %s, %s within %s km" % (lat, lng, distance))
     flight = None
@@ -368,6 +389,6 @@ def main(config):
         print("[%s] %s → %s, %s, %s" % (flight["airline"], flight["origin"], flight["destination"], flight["flightNumber"], flight["aircraftType"]))
 
     return render.Root(
-        child = update_display(TAILS.get(flight["airline"], DEFAULT_TAIL), text),
+        child = update_display(get_tail_image(flight["airline"], logostream_api_key), text),
         show_full_animation = True,
     )

--- a/apps/flightsnearby_adsb/manifest.yaml
+++ b/apps/flightsnearby_adsb/manifest.yaml
@@ -7,5 +7,5 @@ author: vtsao
 fileName: flightsnearby_adsb.star
 packageName: flightsnearby_adsb
 published: '2026-06-30T19:20:48Z'
-updated: '2026-08-10T15:49:06Z'
+updated: '2026-08-10T15:53:25Z'
 tags: []

--- a/apps/flightsnearby_adsb/manifest.yaml
+++ b/apps/flightsnearby_adsb/manifest.yaml
@@ -7,5 +7,5 @@ author: vtsao
 fileName: flightsnearby_adsb.star
 packageName: flightsnearby_adsb
 published: '2026-06-30T19:20:48Z'
-updated: '2026-06-30T19:27:20Z'
+updated: '2026-08-10T15:49:06Z'
 tags: []


### PR DESCRIPTION
## Summary
- `flightsnearby_adsb` only shows a tail logo for the ~30 airlines hardcoded in `TAILS`; everyone else gets the generic `DEFAULT_TAIL` icon.
- Adds an optional, secret `logostream_api_key` schema field that fetches a tail logo from [logostream.dev](https://airline.logostream.dev/) by ICAO code when the airline isn't in the built-in list.
- Mirrors the pattern already merged for `flightsnearby_ha` in #422: same field name/desc, same `ttl_seconds = 86400` caching, same "try dynamic source, else fall back" shape.
- Zero behavior change for the ~30 airlines already in `TAILS`, and zero behavior change for anyone who doesn't set a key — `DEFAULT_TAIL` fallback is untouched.

## Test plan
- [x] `pixlet check apps/flightsnearby_adsb/flightsnearby_adsb.star` — passes
- [x] `pixlet lint apps/flightsnearby_adsb/flightsnearby_adsb.star` — passes
- [x] `pixlet format` — no diff, already matches repo style
- [ ] Live Logostream lookup for an airline outside the built-in 30 (needs a real API key + a nearby flight matching one at render time — couldn't reproduce headless; happy to verify with a key on request, or maintainer can spot-check)

Airline logos provided by [Logostream](https://airline.logostream.dev/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Logostream API-key support to display airline tail logos beyond the built-in collection.
  * Automatically falls back to built-in artwork when logos are unavailable or no API key is configured.

* **Documentation**
  * Updated configuration guidance for the optional Logostream API key.

* **Chores**
  * Updated application metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->