### PR TITLE
Handle teams with no games in win percentage calculation

### DIFF
--- a/apps/sleeperfantasyfootball/manifest.yaml
+++ b/apps/sleeperfantasyfootball/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - nfl
   - football
 published: '2023-08-23T14:14:46Z'
-updated: '2025-11-29T17:52:33Z'
+updated: '2026-08-14T11:52:33Z'

--- a/apps/sleeperfantasyfootball/manifest.yaml
+++ b/apps/sleeperfantasyfootball/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - nfl
   - football
 published: '2023-08-23T14:14:46Z'
-updated: '2026-08-14T11:52:33Z'
+updated: '2026-08-14T15:55:56Z'

--- a/apps/sleeperfantasyfootball/sleeperfantasynfl.star
+++ b/apps/sleeperfantasyfootball/sleeperfantasynfl.star
@@ -292,7 +292,10 @@ def get_team_winning_percentage(user_and_roster_map, league_rosters):
         team_wins = team["settings"]["wins"]
         team_losses = team["settings"]["losses"]
         team_ties = team["settings"]["ties"]
-        team_winning_pct_calc = (2 * team_wins) / (2 * (team_wins + team_losses + team_ties))
+        if team_wins + team_losses + team_ties == 0:
+            team_winning_pct_calc = team["roster_id"]
+        else:
+            team_winning_pct_calc = (2 * team_wins) / (2 * (team_wins + team_losses + team_ties))
         team_winning_percentage[user_and_roster_map[team["roster_id"]]["username"]] = team_winning_pct_calc
 
     sorted_team_winning_percentage = sorted(team_winning_percentage.items(), key = lambda x: x[1], reverse = True)


### PR DESCRIPTION
if no games have been played just return rosterId for win percentage to avoid exception

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team standings calculations for teams without recorded wins, losses, or ties.
  * Ensured teams with no game results are still consistently included and ordered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->