### PR TITLE
Add Lake Lanier wave and ticker toggles

### DIFF
--- a/apps/lake-lanier-water-level/README.md
+++ b/apps/lake-lanier-water-level/README.md
@@ -8,4 +8,6 @@ Live water-level display for **Lake Sidney Lanier (GA)** on a 64×32 LED matrix.
 - **Scrolling ticker** with level, temp, and last-update time
 - **Zone color bar** along the bottom
 
+In app settings you can turn **Animate waves** off for a still surface, and turn **Scrolling ticker** off to show only the last-update time (the rest of the ticker repeats the header and hero). Both default on.
+
 Data comes from the [Lanier Level Watch](https://lanierlevel.com) public API (USGS gauge, refreshed hourly).

--- a/apps/lake-lanier-water-level/lanier_level.star
+++ b/apps/lake-lanier-water-level/lanier_level.star
@@ -151,6 +151,9 @@ def main(config):
     if not data:
         return []
 
+    animate = config.bool("animate", True)
+    show_ticker = config.bool("show_ticker", True)
+
     diff = float(data.get("feet_above_full") or 0.0)
     trend = data.get("trend") or "down"
     temp_raw = data.get("water_temp_f")
@@ -163,12 +166,15 @@ def main(config):
     temp_str = ("%dF" % int(temp_raw + 0.5)) if temp_raw != None else ""
     updated = fmt_time(updated_iso, timezone)
 
-    # ── Water (animated, positioned at row 14) ───────────────────────
-    wave_anim = render.Animation(children = [
-        wave_frame(f * 0.18, accent)
-        for f in range(WAVE_FRAMES)
-    ])
-    water_layer = render.Padding(pad = (0, WAVE_TOP, 0, 0), child = wave_anim)
+    # ── Water (positioned at row 14); optional ripple ────────────────
+    if animate:
+        water_child = render.Animation(children = [
+            wave_frame(f * 0.18, accent)
+            for f in range(WAVE_FRAMES)
+        ])
+    else:
+        water_child = wave_frame(0, accent)
+    water_layer = render.Padding(pad = (0, WAVE_TOP, 0, 0), child = water_child)
 
     # ── Header (rows 0-4): LANIER · temp ─────────────────────────────
     header = render.Row(
@@ -209,30 +215,45 @@ def main(config):
     ticker_pieces.append(" UPDATED " + updated)
     ticker_text = "  ·  ".join(ticker_pieces) + "  ·  "
 
-    bottom = render.Column(children = [
-        render.Box(width = 64, height = BOTTOM_BAND_Y),  # transparent spacer
-        dotted_divider(),
-        render.Box(width = 64, height = 1),
-        render.Marquee(
+    if show_ticker:
+        ticker_row = render.Marquee(
             width = 64,
             child = render.Text(
                 ticker_text,
                 font = "CG-pixel-3x5-mono",
                 color = COLOR_WHITE,
             ),
-        ),
+        )
+    else:
+        ticker_row = render.Row(
+            expanded = True,
+            main_align = "center",
+            children = [
+                render.Text(
+                    "UPDATED " + updated,
+                    font = "CG-pixel-3x5-mono",
+                    color = COLOR_WHITE,
+                ),
+            ],
+        )
+
+    bottom = render.Column(children = [
+        render.Box(width = 64, height = BOTTOM_BAND_Y),  # transparent spacer
+        dotted_divider(),
+        render.Box(width = 64, height = 1),
+        ticker_row,
         render.Box(width = 64, height = 1),
         zone_bar(),
     ])
 
-    return render.Root(
-        delay = 100,
-        child = render.Stack(children = [
-            water_layer,
-            text_overlay,
-            bottom,
-        ]),
-    )
+    stack = render.Stack(children = [
+        water_layer,
+        text_overlay,
+        bottom,
+    ])
+    if animate or show_ticker:
+        return render.Root(delay = 100, child = stack)
+    return render.Root(child = stack)
 
 def get_schema():
     return schema.Schema(
@@ -243,6 +264,20 @@ def get_schema():
                 name = "Location",
                 desc = "Timezone used for the last-update time in the ticker.",
                 icon = "locationDot",
+            ),
+            schema.Toggle(
+                id = "animate",
+                name = "Animate waves",
+                desc = "Ripple the water surface. Turn off for a static display.",
+                icon = "water",
+                default = True,
+            ),
+            schema.Toggle(
+                id = "show_ticker",
+                name = "Scrolling ticker",
+                desc = "Scroll extra status text. Off shows only the last-update time.",
+                icon = "textWidth",
+                default = True,
             ),
         ],
     )

--- a/apps/lake-lanier-water-level/manifest.yaml
+++ b/apps/lake-lanier-water-level/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - water level
   - lake
 published: '2026-04-07T20:59:29Z'
-updated: '2026-08-14T17:42:45Z'
+updated: '2026-08-14T18:35:30Z'


### PR DESCRIPTION
## Summary

Follow-up to #602 after [@tavdog](https://github.com/tavdog)'s review notes: animation can be distracting, and the ticker mostly duplicates data already on screen.

Adds two optional schema toggles (both default **on**, so the gallery preview and existing installs stay the same):

- **Animate waves** — freeze the water surface when off
- **Scrolling ticker** — when off, show a static `UPDATED 3:04P` instead of the marquee (that timestamp is the only ticker field not already in the header/hero)

When both are off, `render.Root` omits `delay` so the device shows a still frame.

## Test plan

- [x] `pixlet check apps/lake-lanier-water-level`
- [x] `pixlet render apps/lake-lanier-water-level/lanier_level.star` (default)
- [x] `pixlet render ... animate=false show_ticker=false` (fully static)
- [x] `pixlet render ... animate=false show_ticker=true`
- [x] `pixlet render ... animate=true show_ticker=false`