### PR TITLE
Update metar.star with new param name

### DIFF
--- a/apps/metar/manifest.yaml
+++ b/apps/metar/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - weather
   - utility
 published: '2022-07-08T18:02:38Z'
-updated: '2026-02-14T17:55:02Z'
+updated: '2026-08-17T16:45:09Z'

--- a/apps/metar/metar.star
+++ b/apps/metar/metar.star
@@ -11,7 +11,7 @@ load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 
-ADDS_URL = "https://aviationweather.gov/api/data/metar?ids=%s&format=json&hoursBeforeNow=2"
+ADDS_URL = "https://aviationweather.gov/api/data/metar?ids=%s&format=json&hours=2"
 DEFAULT_AIRPORT = "KJFK, KLGA, KBOS, KDCA"
 
 # encryption, schema


### PR DESCRIPTION
Parameter name update that was causing an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated METAR data requests to use the current time-range parameter, improving compatibility with the API.
- **Chores**
  - Refreshed the METAR application metadata timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->