### PR TITLE
feat:metar auto prefix 3 letter codes with K

### DIFF
--- a/apps/metar/manifest.yaml
+++ b/apps/metar/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - weather
   - utility
 published: '2022-07-08T18:02:38Z'
-updated: '2026-08-17T16:45:09Z'
+updated: '2026-08-20T23:08:03Z'

--- a/apps/metar/metar.star
+++ b/apps/metar/metar.star
@@ -20,6 +20,13 @@ DEFAULT_AIRPORT = "KJFK, KLGA, KBOS, KDCA"
 
 MAX_AGE = 60 * 10
 
+def normalize_airport(airport):
+    # Users often enter 3-letter US airport codes (e.g. JFK); prepend
+    # the US ICAO prefix "K" so lookups work without it.
+    if len(airport) == 3:
+        return "K" + airport
+    return airport
+
 def decoded_result_for_airport(airport):
     rep = http.get(ADDS_URL % airport, ttl_seconds = 60)
     if rep.status_code == 204:
@@ -303,7 +310,7 @@ def get_schema():
             schema.Text(
                 id = "icao",
                 name = "Airport(s)",
-                desc = "Comma-separated list of ICAO airport codes. Use just one for METAR text.",
+                desc = "Comma-separated list of ICAO airport codes. Use just one for METAR text. 3-letter US codes (e.g. JFK) are automatically prefixed with K.",
                 icon = "plane",
             ),
             schema.Toggle(
@@ -319,7 +326,7 @@ def get_schema():
 def main(config):
     airports = config.get("icao") or DEFAULT_AIRPORT
     airports = airports.upper()
-    airports = [a.strip() for a in airports.split(",")]
+    airports = [normalize_airport(a.strip()) for a in airports.split(",")]
     if len(airports) == 1:
         return render_single_airport(config, airports[0])
     elif len(airports) <= 4:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Airport codes with three letters are now automatically prefixed with “K” for U.S. airports.
  - Airport configuration entries are trimmed and normalized for more consistent processing.

- **Documentation**
  - Updated the configuration schema description to explain automatic airport-code normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->