### PR TITLE
Fonts in date progress (follow-up to #620)

### DIFF
--- a/apps/dateprogress/date_progress.star
+++ b/apps/dateprogress/date_progress.star
@@ -27,7 +27,11 @@ P_COLOR_DAY = "#f00"  # Red
 
 SCALE = 2 if canvas.is2x() else 1
 FRAME_WIDTH = 64 * SCALE
-FONT = "terminus-16" if canvas.is2x() else "tb-8"
+
+# tom-thumb (height 6) renders the tightest, cleanest bars at 1x; the
+# recommended tb-8/terminus-16 pairing looked bulky here. terminus-12
+# (height 12) is the closest 2x match to tom-thumb's proportions.
+FONT = "terminus-12" if canvas.is2x() else "tom-thumb"
 
 def lightness(color, amount):
     hsl_color = rgb_to_hsl(*hex_to_rgb(color))

--- a/apps/dateprogress/manifest.yaml
+++ b/apps/dateprogress/manifest.yaml
@@ -15,4 +15,4 @@ tags:
   - art
   - utility
 published: '2022-02-02T01:17:26Z'
-updated: '2026-08-21T01:33:37Z'
+updated: '2026-08-21T01:40:39Z'


### PR DESCRIPTION
Follow-up to #620 — the font fix from review landed on datepro_fw_fs after [#620](https://github.com/frame-shift/tronbyt-apps/issues/620) was already merged, so it never made it into main. Reverts the 2x font pairing from the generic tb-8/terminus-16 default to tom-thumb/terminus-12: tom-thumb (6px) draws the tightest, cleanest bars at 1x, and terminus-12 (12px) is the closest 2x match to its proportions, keeping the same clean look scaled up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the date progress display fonts for improved readability at both standard and high-density scales.

* **Chores**
  * Refreshed the application update metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->