### PR TITLE
NFL Play By Play: poll every 10s during live games

### DIFF
--- a/apps/nflplaybyplay/manifest.yaml
+++ b/apps/nflplaybyplay/manifest.yaml
@@ -14,4 +14,4 @@ tags:
   - sports
   - live
 published: '2026-08-23T02:29:10Z'
-updated: '2026-08-23T02:29:10Z'
+updated: '2026-08-24T16:16:50Z'

--- a/apps/nflplaybyplay/nfl_play_by_play.star
+++ b/apps/nflplaybyplay/nfl_play_by_play.star
@@ -31,7 +31,7 @@ API_BASE = "https://site.api.espn.com"
 SCOREBOARD_PATH = "/apis/site/v2/sports/football/nfl/scoreboard"
 STANDINGS_PATH = "/apis/v2/sports/football/nfl/standings?level=3"
 
-FRESH_LIVE = 30  # live game: re-poll every 30s
+FRESH_LIVE = 10  # live game: re-poll every 10s (ESPN serves max-age=2; a play cycle is ~40s)
 FRESH_IDLE = 600  # no live game: every 10 min
 RETRY_TTL = 60  # back off after a failure
 STALE_TTL = 21600  # serve last good extract up to 6h through an outage


### PR DESCRIPTION
Follow-up to #622. One-line change: `FRESH_LIVE` 30s → 10s.

**Why:** during a live game, plays resolve every ~40 seconds. With a 30s data TTL, the board could show the previous down/distance for most of a play cycle. At 10s the display tracks the broadcast within a play.

**API politeness:** unchanged in spirit — ESPN serves this scoreboard endpoint with `cache-control: max-age=2` (~23KB gzipped), and the fast poll only runs while the followed team is actually in a live game. Idle polling stays at 600s and failure backoff at 60s.

Verified on-device tonight during SEA–TEN (preseason week 3): score, possession, down/distance, and red-zone state all updated correctly at the faster cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live game updates now refresh every 10 seconds instead of every 30 seconds, providing more up-to-date play-by-play information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->