### PR TITLE
Fix Birdbyt location parameters for current runtime

### DIFF
--- a/apps/birdbyt/birdbyt.star
+++ b/apps/birdbyt/birdbyt.star
@@ -51,8 +51,8 @@ def get_params(config):
 
     location = config.get("location")
     loc = json.decode(location) if location else DEFAULT_LOCATION
-    params["lat"] = str["lat"]
-    params["lng"] = str["lng"]
+    params["lat"] = str(loc["lat"])
+    params["lng"] = str(loc["lng"])
     params["tz"] = loc["timezone"] if time.is_valid_timezone(loc["timezone"]) else DEFAULT_LOCATION["timezone"]
 
     params["dist"] = config.get("distance") or DEFAULT_DISTANCE

--- a/apps/birdbyt/birdbyt.star
+++ b/apps/birdbyt/birdbyt.star
@@ -51,8 +51,8 @@ def get_params(config):
 
     location = config.get("location")
     loc = json.decode(location) if location else DEFAULT_LOCATION
-    params["lat"] = loc["lat"]
-    params["lng"] = loc["lng"]
+    params["lat"] = str["lat"]
+    params["lng"] = str["lng"]
     params["tz"] = loc["timezone"] if time.is_valid_timezone(loc["timezone"]) else DEFAULT_LOCATION["timezone"]
 
     params["dist"] = config.get("distance") or DEFAULT_DISTANCE

--- a/apps/birdbyt/manifest.yaml
+++ b/apps/birdbyt/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - weather
   - local
 published: '2023-06-15T20:32:24Z'
-updated: '2025-12-02T19:30:22Z'
+updated: '2026-08-26T20:36:11Z'

--- a/apps/birdbyt/manifest.yaml
+++ b/apps/birdbyt/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - weather
   - local
 published: '2023-06-15T20:32:24Z'
-updated: '2026-08-26T20:36:11Z'
+updated: '2026-08-26T21:15:48Z'


### PR DESCRIPTION
Birdbyt currently passes latitude and longitude from the location config directly to http.get().

The current Tronbyt runtime returns an error when these values are floats:

expected param value for key "lat" to be a string, got: "float"

This change converts lat and lng to strings before passing them as URL parameters.

Tested with a Tronbyt server running the current 2.x image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Location-based results now use the latitude and longitude provided with the request, improving accuracy for specified locations.

* **Chores**
  * Updated the application metadata timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->