### PR TITLE
Fix JSON_ENDPOINT URL for literature_clock

### DIFF
--- a/apps/literatureclock/literature_clock.star
+++ b/apps/literatureclock/literature_clock.star
@@ -11,7 +11,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-JSON_ENDPOINT = "https://raw.githubusercontent.com/JohannesNE/literature-clock/refs/heads/master/docs/times/"
+JSON_ENDPOINT = "https://raw.githubusercontent.com/JohsEnevoldsen/literature-clock/refs/heads/master/docs/times/"
 QUOTE_FIRST = "quote_first"
 QUOTE_TIME = "quote_time_case"
 QUOTE_LAST = "quote_last"

--- a/apps/literatureclock/manifest.yaml
+++ b/apps/literatureclock/manifest.yaml
@@ -14,4 +14,4 @@ tags:
   - clock
   - poetry
 published: '2023-03-14T19:19:36Z'
-updated: '2025-12-02T19:30:22Z'
+updated: '2026-08-30T17:40:12Z'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Literature Clock’s quote data source to the correct repository location.
* **Chores**
  * Refreshed the Literature Clock metadata timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->