### PR TITLE
Fix MBTA stop list failing to load for device-supplied locations

### DIFF
--- a/apps/mbta/manifest.yaml
+++ b/apps/mbta/manifest.yaml
@@ -10,4 +10,4 @@ recommendedInterval: 5
 category: transit
 tags: []
 published: '2022-02-01T21:38:47Z'
-updated: '2025-11-29T17:52:33Z'
+updated: '2026-08-31T23:57:56Z'

--- a/apps/mbta/manifest.yaml
+++ b/apps/mbta/manifest.yaml
@@ -10,4 +10,4 @@ recommendedInterval: 5
 category: transit
 tags: []
 published: '2022-02-01T21:38:47Z'
-updated: '2026-08-31T23:57:56Z'
+updated: '2026-09-01T00:22:14Z'

--- a/apps/mbta/manifest.yaml
+++ b/apps/mbta/manifest.yaml
@@ -10,4 +10,4 @@ recommendedInterval: 5
 category: transit
 tags: []
 published: '2022-02-01T21:38:47Z'
-updated: '2026-09-01T00:22:14Z'
+updated: '2026-09-03T02:14:12Z'

--- a/apps/mbta/mbta.star
+++ b/apps/mbta/mbta.star
@@ -176,16 +176,32 @@ def find(xs, pred):
 
 def get_stops(location):
     loc = json.decode(location)
+
+    # The location object reaches this handler two ways, and they disagree on
+    # type. A fresh pick in the location search box yields strings, matching the
+    # documented schema. A location restored from the device record yields JSON
+    # numbers, because the server stores the coordinates as floats. http.get
+    # rejects non-string params, so the second path used to abort the handler and
+    # surface in the UI as "Error loading options" with no way to recover.
+    lat = loc.get("lat")
+    lng = loc.get("lng")
+    if lat == None or lng == None or lat == "" or lng == "":
+        return []
+
     params = {
         "page[limit]": "100",
-        "filter[latitude]": loc["lat"],
-        "filter[longitude]": loc["lng"],
+        "filter[latitude]": str(lat),
+        "filter[longitude]": str(lng),
         "sort": "distance",
     }
 
     rep = http.get("https://api-v3.mbta.com/stops", params = params)
     if rep.status_code != 200:
-        fail("MBTA API request failed with status {}".format(rep.status_code))
+        # Returning no options leaves the picker empty but retryable. Failing
+        # hard here is indistinguishable, to the user, from a broken app, and
+        # keyless clients are throttled at 20 requests/minute so a non-200 is
+        # reachable from the settings screen alone.
+        return []
     data = rep.json()
     stops = []
     for s in data["data"]:

--- a/apps/mbta/mbta.star
+++ b/apps/mbta/mbta.star
@@ -175,7 +175,14 @@ def find(xs, pred):
     return None
 
 def get_stops(location):
-    loc = json.decode(location)
+    # The handler is also reached with values that are not a location object at
+    # all. An empty string fails to decode, and the settings page sends the
+    # literal "null" whenever the device itself has no location set, since it
+    # stringifies a null device location into the field. Both aborted the handler,
+    # which the UI reports only as "Error loading options".
+    loc = json.decode(location, None) if location else None
+    if type(loc) != "dict":
+        return []
 
     # The location object reaches this handler two ways, and they disagree on
     # type. A fresh pick in the location search box yields strings, matching the


### PR DESCRIPTION
### Problem

The MBTA stop dropdown populates the first time you pick a location, then shows **"Error loading options"** on every later load of the settings page, until you remove and re-add the location. It reads like the app is filtering stops out of the list, but the handler is aborting before it returns anything.

`get_stops` passes the location's `lat`/`lng` straight into `http.get`, and the runtime rejects non-string params:

```
expected param value for key "filter[latitude]" to be a string. got: 'float'
```

The location object reaches the handler two ways and they disagree on type. A fresh pick in the location search box yields strings, matching the [documented schema](https://github.com/tronbyt/pixlet/blob/main/docs/schema/schema.md). A location restored from the device record yields JSON numbers, because the server stores the coordinates as floats. Hence the "works once, then stops" behaviour.

Same root cause and same fix as #633 for Birdbyt.

### Changes

- `str()` coercion on `lat`/`lng`.
- Return no options when the location carries no coordinates at all. That case raised `key "lat" not in dict`, producing the identical opaque error.
- Return no options instead of `fail()` on a non-200. Keyless clients are throttled at 20 requests/minute, so this is reachable from the settings screen alone, and an empty-but-retryable picker beats a dead end.

### Verification

Exercised through `pixlet serve`'s handler API, which is the path `pixlet check` never touches:

| location payload | before | after |
|---|---|---|
| `lat`/`lng` as strings | 26 options | 26 options |
| `lat`/`lng` as numbers | crash | 26 options |
| no `lat`/`lng` | crash | 0 options |
| `{}` | crash | 0 options |
| non-200 response | crash | 0 options |

Reference stop is `9306` North Ave @ Church St, which is the first option returned in both passing cases.

`pixlet format`, `pixlet lint` and `pixlet check apps/mbta` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transit stop lookups when location coordinates are unavailable.
  * Formatted latitude and longitude values correctly for MBTA requests.
  * Prevented failures when the MBTA stops service returns an unsuccessful response by showing no available stops instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
