### PR TITLE
Fix NYC Bus location parameters for current runtime

### DIFF
--- a/apps/nycbus/manifest.yaml
+++ b/apps/nycbus/manifest.yaml
@@ -11,4 +11,4 @@ tags:
   - local
   - utility
 published: '2022-02-24T03:27:18Z'
-updated: '2025-12-23T13:24:18Z'
+updated: '2026-08-31T23:58:26Z'

--- a/apps/nycbus/nyc_bus.star
+++ b/apps/nycbus/nyc_bus.star
@@ -48,9 +48,9 @@ def get_stops(location, config):
         BUSTIME_STOPS_FOR_LOCATION_URL,
         params = {
             "key": api_key,
-            "lat": loc["lat"],
+            "lat": str(loc["lat"]),
             "latSpan": "0.001",
-            "lon": loc["lng"],
+            "lon": str(loc["lng"]),
             "longSpan": "0.001",
         },
     )


### PR DESCRIPTION
### Problem

Same issue as #633 (Birdbyt) and #646 (MBTA). `get_stops` passes the location's `lat`/`lng` straight into the BusTime request, and the runtime rejects non-string params:

```
expected param value for key "lat" to be a string. got: 'float'
```

A location restored from the device record supplies these as JSON numbers, because the server stores coordinates as floats, so the stop dropdown shows "Error loading options" until the location is removed and re-added.

### Changes

Two-line `str()` coercion on the params dict.

The distance sort just below already wraps both values in `float()`, which tolerates either type, so only the params dict needed changing.

### Verification

`pixlet format`, `pixlet lint` and `pixlet check apps/nycbus` all clean. The handler itself needs an MTA BusTime API key to exercise end to end, so I have not run it live; the change mirrors #633 exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bus stop searches by ensuring location coordinates are sent in the expected format.
* **Maintenance**
  * Updated the NYC Bus service metadata timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Testing caveat

I have not executed this code path. Exercising `get_stops` needs an MTA BusTime
API key, which I do not have, so this change is verified only by `pixlet format`,
`pixlet lint` and `pixlet check apps/nycbus`.

It is a mechanical mirror of #633, which fixed the identical crash in `birdbyt`
with the same `str()` coercion and the same runtime error text. I confirmed by
reading the source that the distance sort below already wraps both values in
`float()`, so the params dict is the only place that needed changing.

Flagging it rather than implying verification I did not do. Happy to hold this
until someone with a BusTime key can confirm it against the live API.
