### PR TITLE
Fix WNBA Scores app

### DIFF
--- a/apps/wnbascores/manifest.yaml
+++ b/apps/wnbascores/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - nba
   - basketball
 published: '2022-09-01T16:38:34Z'
-updated: '2026-09-01T18:29:09Z'
+updated: '2026-09-01T19:02:11Z'

--- a/apps/wnbascores/manifest.yaml
+++ b/apps/wnbascores/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - nba
   - basketball
 published: '2022-09-01T16:38:34Z'
-updated: '2025-12-05T22:28:51Z'
+updated: '2026-09-01T18:29:09Z'

--- a/apps/wnbascores/manifest.yaml
+++ b/apps/wnbascores/manifest.yaml
@@ -6,7 +6,6 @@ desc: Creating multiple app instances is no longer necessary. Just install once 
 author: lunchbox8484
 fileName: wnba_scores.star
 packageName: wnbascores
-broken: true
 recommendedInterval: 5
 category: sports
 tags:

--- a/apps/wnbascores/wnba_scores.star
+++ b/apps/wnbascores/wnba_scores.star
@@ -816,9 +816,12 @@ def get_logoType(team, logo):
     if usealt != "NO":
         logo = get_cachable_data(usealt, 36000)
     else:
-        logo = logo.replace("500/scoreboard", "500-dark/scoreboard")
-        logo = logo.replace("https://a.espncdn.com/", "https://a.espncdn.com/combiner/i?img=", 36000)
-        logo = get_cachable_data(logo + "&h=50&w=50")
+        # ESPN serves a mix of "500/<abbr>.png" and "500/scoreboard/<abbr>.png",
+        # but only the plain "500-dark/<abbr>.png" variant exists for every team.
+        logo = logo.replace("500/scoreboard", "500")
+        logo = logo.replace("/500/", "/500-dark/")
+        logo = logo.replace("https://a.espncdn.com/", "https://a.espncdn.com/combiner/i?img=")
+        logo = get_cachable_data(logo + "&h=50&w=50", 36000)
     return logo
 
 def get_logoSize(team):

--- a/apps/wnbascores/wnba_scores.star
+++ b/apps/wnbascores/wnba_scores.star
@@ -495,7 +495,7 @@ teamOptions = [
     ),
     schema.Option(
         display = "Connecticut Sun",
-        value = "CONN",
+        value = "CON",
     ),
     schema.Option(
         display = "Dallas Wings",
@@ -530,8 +530,16 @@ teamOptions = [
         value = "PHX",
     ),
     schema.Option(
+        display = "Portland Fire",
+        value = "POR",
+    ),
+    schema.Option(
         display = "Seattle Storm",
         value = "SEA",
+    ),
+    schema.Option(
+        display = "Toronto Tempo",
+        value = "TOR",
     ),
     schema.Option(
         display = "Washington Mystics",


### PR DESCRIPTION
- WNBA Scores works again and is no longer hidden from the app list
- Every team's logo now loads, and logos render consistently against the dark background
- All 15 teams can now be followed, including Portland Fire and Toronto Tempo
- Following the Connecticut Sun works instead of showing a permanently blank screen
