### PR TITLE
wordclock: add German, Spanish, Italian, Portuguese, Chinese and Japanese, and a 64x64 layout

### DIFF
--- a/apps/wordclock/manifest.yaml
+++ b/apps/wordclock/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - clock
   - utility
 published: '2023-06-29T14:29:50Z'
-updated: '2026-09-02T06:42:41Z'
+updated: '2026-09-02T12:30:59Z'

--- a/apps/wordclock/manifest.yaml
+++ b/apps/wordclock/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - clock
   - utility
 published: '2023-06-29T14:29:50Z'
-updated: '2026-09-02T12:30:59Z'
+updated: '2026-09-02T15:17:54Z'

--- a/apps/wordclock/manifest.yaml
+++ b/apps/wordclock/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - clock
   - utility
 published: '2023-06-29T14:29:50Z'
-updated: '2026-09-02T03:00:15Z'
+updated: '2026-09-02T06:42:41Z'

--- a/apps/wordclock/manifest.yaml
+++ b/apps/wordclock/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - clock
   - utility
 published: '2023-06-29T14:29:50Z'
-updated: '2026-09-02T15:17:54Z'
+updated: '2026-09-03T04:50:18Z'

--- a/apps/wordclock/word_clock.star
+++ b/apps/wordclock/word_clock.star
@@ -8,7 +8,7 @@ Description: Display the accurate time in a human-readable way. Inspired by Max 
 load("encoding/json.star", "json")
 load("math.star", "math")
 load("random.star", "random")
-load("render.star", "render")
+load("render.star", "canvas", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
@@ -2480,17 +2480,38 @@ cjkGlyphs = {
     "兩": "000ffe040ffe842b5a94a94aad6c62842846",
 }
 
-CJK_SIZE = 12
+cjkGlyphs16 = {
+    "零": "00003ffc01007ffe41025d7a41021d78028004401ff0600e1ff0011001600100",
+    "一": "00000000000000000000000000027fff00000000000000000000000000000000",
+    "二": "000000001ffc00000000000000000000000000000000000000007fff00000000",
+    "三": "00001ffc000000000000000000000ff8000000000000000000007fff00000000",
+    "四": "000000007ffe444244424442444244464846483e5002600240027ffe00000000",
+    "五": "00003ffe00800080008000801ff801080108010801080208020802087fff0000",
+    "六": "00800080008000807fff00000000000004200410040808080804100420040000",
+    "七": "04000400040004000406047807807c0004000400040004040404020401fc0000",
+    "八": "000003e000200020042004200420042004100410041008080808100420024001",
+    "九": "00000200020002007fe0022002200220022004200420042008221022201e4000",
+    "十": "0080008000800080008000807fff008000800080008000800080008000800080",
+    "点": "00800080008000fe008000800ff80808080808080ff800001008124421224122",
+    "時": "002000207dfe44204420442047ff7c04440447ff450444847c8400040004000c",
+    "分": "03e00020042004100810080810042ff241110110011002100210041008101060",
+    "半": "0080008410840888049004803ffe0080008000807fff00800080008000800080",
+    "刻": "040204227fe20422042239220a22062204a208a2112223020482084210426006",
+    "差": "041002201ffe008000800ff8008000807fff040007fc0840084010402fff4000",
+    "整": "04207fa0043f3f6425543f940e08153464c204011ffc008008f808807fff0000",
+    "兩": "00007fff008000803ffe208220822cb2249224922aaa2aaa31c6208220822086",
+}
 
-# the glyph box is inked edge to edge, so stacked lines need explicit leading
+# A square panel is the same 64px wide but twice as tall, so CJK moves up to the
+# 16-dot cut of the same font: still four glyphs to a line, far more legible.
 CJK_LEAD = 2
 
-def cjk_row(bits, color):
+def cjk_row(bits, size, color):
     children = []
     run = 0
     gap = 0
-    for i in range(CJK_SIZE):
-        if (bits >> (CJK_SIZE - 1 - i)) & 1:
+    for i in range(size):
+        if (bits >> (size - 1 - i)) & 1:
             if gap > 0:
                 children.append(render.Box(width = gap, height = 1))
                 gap = 0
@@ -2506,19 +2527,86 @@ def cjk_row(bits, color):
         children.append(render.Box(width = gap, height = 1))
     return render.Row(children = children)
 
-def cjk_char(ch, color):
-    hexrows = cjkGlyphs.get(ch)
+def cjk_char(ch, size, color):
+    table = cjkGlyphs16 if size == 16 else cjkGlyphs
+    hexrows = table.get(ch)
     if not hexrows:
-        return render.Box(width = CJK_SIZE, height = CJK_SIZE)
+        return render.Box(width = size, height = size)
+
+    # one hex digit per four pixels of row: three digits at 12, four at 16
+    digits = size // 4
     return render.Column(
-        children = [cjk_row(int(hexrows[i * 3:(i + 1) * 3], 16), color) for i in range(CJK_SIZE)],
+        children = [
+            cjk_row(int(hexrows[i * digits:(i + 1) * digits], 16), size, color)
+            for i in range(size)
+        ],
     )
 
-def cjk_line(text, color):
+def cjk_line(text, size, color):
     return render.Padding(
         pad = (0, 0, 0, CJK_LEAD),
-        child = render.Row(children = [cjk_char(c, color) for c in text.codepoints()]),
+        child = render.Row(children = [cjk_char(c, size, color) for c in text.codepoints()]),
     )
+
+# On a square panel the text font grows from tb-8 to 6x10. The panel is no wider,
+# so lines have to be rebroken: 6x10 is a fixed 6px advance and 10 characters is
+# 60px of the 63 available.
+SQUARE_COLS = 10
+
+# Every word the tables can emit that is longer than the budget and has no space
+# or hyphen to break on. Each splits at a compound or syllable boundary. Keyed on
+# the authored case, because wrapping runs before the lettercase styling.
+squareBreaks = {
+    "Mitternacht": ["Mitter", "nacht"],
+    "nachmittags": ["nach", "mittags"],
+    "mezzogiorno": ["mezzo", "giorno"],
+    "diciassette": ["dicias", "sette"],
+    "quattordici": ["quattor", "dici"],
+    "veinticinco": ["veinti", "cinco"],
+    "veintisiete": ["veinti", "siete"],
+    "veintinueve": ["veinti", "nueve"],
+    "nightengale": ["nighten", "gale"],
+}
+
+def break_once(line):
+    """Split a line once at the last space or hyphen inside the budget."""
+    if len(line) <= SQUARE_COLS:
+        return [line]
+
+    hard = squareBreaks.get(line)
+    if hard:
+        return hard
+
+    cut = -1
+    for i in range(len(line)):
+        if line[i] == " " and i <= SQUARE_COLS:
+            cut = i
+        elif line[i] == "-" and i + 1 <= SQUARE_COLS:
+            cut = i
+    if cut < 0:
+        return [line]
+
+    head = line[:cut] if line[cut] == " " else line[:cut + 1]
+    return [head, line[cut + 1:]]
+
+def wrap_lines(lines):
+    """Rebreak authored lines to the square budget. Three passes is one more than
+    the longest line the tables can produce needs."""
+    parts = lines
+    for _ in range(3):
+        out = []
+        for p in parts:
+            out += break_once(p)
+        if len(out) == len(parts):
+            return out
+        parts = out
+    return parts
+
+def is_square():
+    """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
+    2x square one 128x128, so a bare height test gets both wrong."""
+    w, h = canvas.size()
+    return h * 2 > w + 16
 
 def to_caps(lines, rules):
     # .upper() leaves "ß" alone, so German would read "DREIßIG"; its uppercase is "SS"
@@ -2529,9 +2617,7 @@ def to_caps(lines, rules):
         out.append(line.upper())
     return out
 
-def calculate_top_margin(showTime, subTime, bigH, littleH):
-    fullHeight = 32
-
+def calculate_top_margin(showTime, subTime, bigH, littleH, fullHeight):
     topMargin = int(math.ceil((fullHeight - (bigH * len(showTime)) - (littleH * len(subTime))) / 2))
 
     # a negative margin silently slices the top off the first line
@@ -2575,8 +2661,26 @@ def main(config):
     if config.bool("time_of_day") and subTime == []:
         subTime = time_of_day(dayPartHour, timeOfDay, config, rules)
 
-    # the panel is 32px tall; drop the subtitle rather than clip the time
-    if (rules["lineHeight"] * len(showTime)) + (rules["subtitleHeight"] * len(subTime)) > 32:
+    # a square panel is the same width but twice as tall, so the text grows and
+    # the lines have to be rebroken to the narrower character budget
+    square = is_square()
+    panelHeight = canvas.height()
+    if square:
+        lineH = 18 if rules["glyphs"] else 10
+        bodyFont = "6x10"
+        subFont = "tb-8"
+        subH = 10
+        if not rules["glyphs"]:
+            showTime = wrap_lines(showTime)
+            subTime = wrap_lines(subTime)
+    else:
+        lineH = rules["lineHeight"]
+        bodyFont = ""
+        subFont = rules["subtitleFont"]
+        subH = rules["subtitleHeight"]
+
+    # drop the subtitle rather than clip the time
+    if (lineH * len(showTime)) + (subH * len(subTime)) > panelHeight:
         subTime = []
 
     # apply lettercase styling
@@ -2586,27 +2690,34 @@ def main(config):
 
     # render the words
     if rules["glyphs"]:
-        textTime = [cjk_line(s, "#fff") for s in showTime]
+        textTime = [cjk_line(s, 16 if square else 12, "#fff") for s in showTime]
+    elif square:
+        # no staircase indent on a square panel: at 6px a space costs more of the
+        # line than the extra height buys back
+        textTime = [render.Text(s, font = bodyFont) for s in showTime]
     else:
         textTime = [render.Text(" " * i + s) for i, s in enumerate(showTime)]
 
-    subIndent = len(showTime) if rules["subtitleCascade"] else 0
+    subIndent = 0 if square else (len(showTime) if rules["subtitleCascade"] else 0)
 
     textTime += [render.Padding(
         pad = (0, 1, 0, 1),
-        child = render.Text(" " * subIndent + " " * i + s, font = rules["subtitleFont"]),
+        child = render.Text(("" if square else " " * (subIndent + i)) + s, font = subFont),
     ) for i, s in enumerate(subTime)]
 
     # center the text vertically
-    topMargin = calculate_top_margin(showTime, subTime, rules["lineHeight"], rules["subtitleHeight"])
+    topMargin = calculate_top_margin(showTime, subTime, lineH, subH, panelHeight)
 
     # once the column already fills the panel, a bottom pad costs it a row --
     # and that row is where the descenders of the last line live
     bottomPad = 1 if topMargin > 0 else 0
 
+    # four 16px glyphs fill a 64px panel exactly, so square CJK gives up its margin
+    leftPad = 0 if (square and rules["glyphs"]) else 1
+
     return render.Root(
         child = render.Padding(
-            pad = (1, topMargin, 0, bottomPad),
+            pad = (leftPad, topMargin, 0, bottomPad),
             child = render.Column(
                 children = textTime,
             ),

--- a/apps/wordclock/word_clock.star
+++ b/apps/wordclock/word_clock.star
@@ -402,6 +402,871 @@ minutesObj = {
             {"text": ["moins", "une"], "h": 1, "o": 2},
         ],
     },
+    "de-DE": {
+        "0": [
+            {"text": [], "h": 0, "o": 2, "military": True},
+            {"text": [], "h": 0, "o": 2},
+            {"text": ["Punkt"], "h": 0, "o": 1},
+        ],
+        "1": [
+            {"text": ["eins"], "h": 0, "o": 2, "military": True},
+            {"text": ["eins"], "h": 0, "o": 2},
+            {"text": ["kurz", "nach"], "h": 0, "o": 1},
+        ],
+        "2": [
+            {"text": ["zwei"], "h": 0, "o": 2, "military": True},
+            {"text": ["zwei"], "h": 0, "o": 2},
+        ],
+        "3": [
+            {"text": ["drei"], "h": 0, "o": 2, "military": True},
+            {"text": ["drei"], "h": 0, "o": 2},
+        ],
+        "4": [
+            {"text": ["vier"], "h": 0, "o": 2, "military": True},
+            {"text": ["vier"], "h": 0, "o": 2},
+        ],
+        "5": [
+            {"text": ["fünf"], "h": 0, "o": 2, "military": True},
+            {"text": ["fünf"], "h": 0, "o": 2},
+            {"text": ["fünf", "nach"], "h": 0, "o": 1},
+        ],
+        "6": [
+            {"text": ["sechs"], "h": 0, "o": 2, "military": True},
+            {"text": ["sechs"], "h": 0, "o": 2},
+        ],
+        "7": [
+            {"text": ["sieben"], "h": 0, "o": 2, "military": True},
+            {"text": ["sieben"], "h": 0, "o": 2},
+        ],
+        "8": [
+            {"text": ["acht"], "h": 0, "o": 2, "military": True},
+            {"text": ["acht"], "h": 0, "o": 2},
+        ],
+        "9": [
+            {"text": ["neun"], "h": 0, "o": 2, "military": True},
+            {"text": ["neun"], "h": 0, "o": 2},
+        ],
+        "10": [
+            {"text": ["zehn"], "h": 0, "o": 2, "military": True},
+            {"text": ["zehn", "nach"], "h": 0, "o": 1},
+        ],
+        "11": [
+            {"text": ["elf"], "h": 0, "o": 2, "military": True},
+        ],
+        "12": [
+            {"text": ["zwölf"], "h": 0, "o": 2, "military": True},
+        ],
+        "13": [
+            {"text": ["dreizehn"], "h": 0, "o": 2, "military": True},
+        ],
+        "14": [
+            {"text": ["vierzehn"], "h": 0, "o": 2, "military": True},
+        ],
+        "15": [
+            {"text": ["fünfzehn"], "h": 0, "o": 2, "military": True},
+            {"text": ["Viertel", "nach"], "h": 0, "o": 1},
+        ],
+        "16": [
+            {"text": ["sechzehn"], "h": 0, "o": 2, "military": True},
+        ],
+        "17": [
+            {"text": ["siebzehn"], "h": 0, "o": 2, "military": True},
+        ],
+        "18": [
+            {"text": ["achtzehn"], "h": 0, "o": 2, "military": True},
+        ],
+        "19": [
+            {"text": ["neunzehn"], "h": 0, "o": 2, "military": True},
+        ],
+        "20": [
+            {"text": ["zwanzig"], "h": 0, "o": 2, "military": True},
+            {"text": ["zwanzig", "nach"], "h": 0, "o": 1},
+            {"text": ["zehn vor", "halb"], "h": 1, "o": 1},
+        ],
+        "21": [
+            {"text": ["einund", "zwanzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "22": [
+            {"text": ["zweiund", "zwanzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "23": [
+            {"text": ["dreiund", "zwanzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "24": [
+            {"text": ["vierund", "zwanzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "25": [
+            {"text": ["fünfund", "zwanzig"], "h": 0, "o": 2, "military": True},
+            {"text": ["fünf vor", "halb"], "h": 1, "o": 1},
+        ],
+        "26": [
+            {"text": ["sechsund", "zwanzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "27": [
+            {"text": ["siebenund", "zwanzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "28": [
+            {"text": ["achtund", "zwanzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "29": [
+            {"text": ["neunund", "zwanzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "30": [
+            {"text": ["dreißig"], "h": 0, "o": 2, "military": True},
+            {"text": ["halb"], "h": 1, "o": 1},
+        ],
+        "31": [
+            {"text": ["einund", "dreißig"], "h": 0, "o": 2, "military": True},
+        ],
+        "32": [
+            {"text": ["zweiund", "dreißig"], "h": 0, "o": 2, "military": True},
+        ],
+        "33": [
+            {"text": ["dreiund", "dreißig"], "h": 0, "o": 2, "military": True},
+        ],
+        "34": [
+            {"text": ["vierund", "dreißig"], "h": 0, "o": 2, "military": True},
+        ],
+        "35": [
+            {"text": ["fünfund", "dreißig"], "h": 0, "o": 2, "military": True},
+            {"text": ["fünf nach", "halb"], "h": 1, "o": 1},
+        ],
+        "36": [
+            {"text": ["sechsund", "dreißig"], "h": 0, "o": 2, "military": True},
+        ],
+        "37": [
+            {"text": ["siebenund", "dreißig"], "h": 0, "o": 2, "military": True},
+        ],
+        "38": [
+            {"text": ["achtund", "dreißig"], "h": 0, "o": 2, "military": True},
+        ],
+        "39": [
+            {"text": ["neunund", "dreißig"], "h": 0, "o": 2, "military": True},
+        ],
+        "40": [
+            {"text": ["vierzig"], "h": 0, "o": 2, "military": True},
+            {"text": ["zwanzig", "vor"], "h": 1, "o": 1},
+            {"text": ["zehn nach", "halb"], "h": 1, "o": 1},
+        ],
+        "41": [
+            {"text": ["einund", "vierzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "42": [
+            {"text": ["zweiund", "vierzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "43": [
+            {"text": ["dreiund", "vierzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "44": [
+            {"text": ["vierund", "vierzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "45": [
+            {"text": ["fünfund", "vierzig"], "h": 0, "o": 2, "military": True},
+            {"text": ["Viertel", "vor"], "h": 1, "o": 1},
+        ],
+        "46": [
+            {"text": ["sechsund", "vierzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "47": [
+            {"text": ["siebenund", "vierzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "48": [
+            {"text": ["achtund", "vierzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "49": [
+            {"text": ["neunund", "vierzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "50": [
+            {"text": ["fünfzig"], "h": 0, "o": 2, "military": True},
+            {"text": ["zehn", "vor"], "h": 1, "o": 1},
+        ],
+        "51": [
+            {"text": ["einund", "fünfzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "52": [
+            {"text": ["zweiund", "fünfzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "53": [
+            {"text": ["dreiund", "fünfzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "54": [
+            {"text": ["vierund", "fünfzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "55": [
+            {"text": ["fünfund", "fünfzig"], "h": 0, "o": 2, "military": True},
+            {"text": ["fünf", "vor"], "h": 1, "o": 1},
+        ],
+        "56": [
+            {"text": ["sechsund", "fünfzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "57": [
+            {"text": ["siebenund", "fünfzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "58": [
+            {"text": ["achtund", "fünfzig"], "h": 0, "o": 2, "military": True},
+        ],
+        "59": [
+            {"text": ["neunund", "fünfzig"], "h": 0, "o": 2, "military": True},
+            {"text": ["kurz", "vor"], "h": 1, "o": 1},
+        ],
+    },
+    "es-ES": {
+        "0": [
+            {"text": [], "h": 0, "o": 2, "military": True},
+            {"text": [], "h": 0, "o": 2},
+            {"text": ["en punto"], "h": 0, "o": 2},
+        ],
+        "1": [
+            {"text": ["uno"], "h": 0, "o": 2, "military": True},
+            {"text": ["y un", "minuto"], "h": 0, "o": 2},
+        ],
+        "2": [
+            {"text": ["dos"], "h": 0, "o": 2, "military": True},
+            {"text": ["y dos"], "h": 0, "o": 2},
+        ],
+        "3": [
+            {"text": ["tres"], "h": 0, "o": 2, "military": True},
+            {"text": ["y tres"], "h": 0, "o": 2},
+        ],
+        "4": [
+            {"text": ["cuatro"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuatro"], "h": 0, "o": 2},
+        ],
+        "5": [
+            {"text": ["cinco"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cinco"], "h": 0, "o": 2},
+        ],
+        "6": [
+            {"text": ["seis"], "h": 0, "o": 2, "military": True},
+            {"text": ["y seis"], "h": 0, "o": 2},
+        ],
+        "7": [
+            {"text": ["siete"], "h": 0, "o": 2, "military": True},
+            {"text": ["y siete"], "h": 0, "o": 2},
+        ],
+        "8": [
+            {"text": ["ocho"], "h": 0, "o": 2, "military": True},
+            {"text": ["y ocho"], "h": 0, "o": 2},
+        ],
+        "9": [
+            {"text": ["nueve"], "h": 0, "o": 2, "military": True},
+            {"text": ["y nueve"], "h": 0, "o": 2},
+        ],
+        "10": [
+            {"text": ["diez"], "h": 0, "o": 2, "military": True},
+            {"text": ["y diez"], "h": 0, "o": 2},
+        ],
+        "11": [
+            {"text": ["once"], "h": 0, "o": 2, "military": True},
+            {"text": ["y once"], "h": 0, "o": 2},
+        ],
+        "12": [
+            {"text": ["doce"], "h": 0, "o": 2, "military": True},
+            {"text": ["y doce"], "h": 0, "o": 2},
+        ],
+        "13": [
+            {"text": ["trece"], "h": 0, "o": 2, "military": True},
+            {"text": ["y trece"], "h": 0, "o": 2},
+        ],
+        "14": [
+            {"text": ["catorce"], "h": 0, "o": 2, "military": True},
+            {"text": ["y catorce"], "h": 0, "o": 2},
+        ],
+        "15": [
+            {"text": ["quince"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuarto"], "h": 0, "o": 2},
+        ],
+        "16": [
+            {"text": ["dieciséis"], "h": 0, "o": 2, "military": True},
+            {"text": ["y dieciséis"], "h": 0, "o": 2},
+        ],
+        "17": [
+            {"text": ["diecisiete"], "h": 0, "o": 2, "military": True},
+            {"text": ["y diecisiete"], "h": 0, "o": 2},
+        ],
+        "18": [
+            {"text": ["dieciocho"], "h": 0, "o": 2, "military": True},
+            {"text": ["y dieciocho"], "h": 0, "o": 2},
+        ],
+        "19": [
+            {"text": ["diecinueve"], "h": 0, "o": 2, "military": True},
+            {"text": ["y diecinueve"], "h": 0, "o": 2},
+        ],
+        "20": [
+            {"text": ["veinte"], "h": 0, "o": 2, "military": True},
+            {"text": ["y veinte"], "h": 0, "o": 2},
+        ],
+        "21": [
+            {"text": ["veintiuno"], "h": 0, "o": 2, "military": True},
+            {"text": ["y veintiuno"], "h": 0, "o": 2},
+        ],
+        "22": [
+            {"text": ["veintidós"], "h": 0, "o": 2, "military": True},
+            {"text": ["y veintidós"], "h": 0, "o": 2},
+        ],
+        "23": [
+            {"text": ["veintitrés"], "h": 0, "o": 2, "military": True},
+            {"text": ["y veintitrés"], "h": 0, "o": 2},
+        ],
+        "24": [
+            {"text": ["veinti", "cuatro"], "h": 0, "o": 2, "military": True},
+            {"text": ["y veinti", "cuatro"], "h": 0, "o": 2},
+        ],
+        "25": [
+            {"text": ["veinticinco"], "h": 0, "o": 2, "military": True},
+            {"text": ["y veinti", "cinco"], "h": 0, "o": 2},
+        ],
+        "26": [
+            {"text": ["veintiséis"], "h": 0, "o": 2, "military": True},
+            {"text": ["y veintiséis"], "h": 0, "o": 2},
+        ],
+        "27": [
+            {"text": ["veintisiete"], "h": 0, "o": 2, "military": True},
+            {"text": ["y veinti", "siete"], "h": 0, "o": 2},
+        ],
+        "28": [
+            {"text": ["veintiocho"], "h": 0, "o": 2, "military": True},
+            {"text": ["y veintiocho"], "h": 0, "o": 2},
+        ],
+        "29": [
+            {"text": ["veintinueve"], "h": 0, "o": 2, "military": True},
+            {"text": ["y veinti", "nueve"], "h": 0, "o": 2},
+        ],
+        "30": [
+            {"text": ["treinta"], "h": 0, "o": 2, "military": True},
+            {"text": ["y media"], "h": 0, "o": 2},
+        ],
+        "31": [
+            {"text": ["treinta", "y uno"], "h": 0, "o": 2, "military": True},
+            {"text": ["y treinta", "y uno"], "h": 0, "o": 2},
+        ],
+        "32": [
+            {"text": ["treinta", "y dos"], "h": 0, "o": 2, "military": True},
+            {"text": ["y treinta", "y dos"], "h": 0, "o": 2},
+        ],
+        "33": [
+            {"text": ["treinta", "y tres"], "h": 0, "o": 2, "military": True},
+            {"text": ["y treinta", "y tres"], "h": 0, "o": 2},
+        ],
+        "34": [
+            {"text": ["treinta", "y cuatro"], "h": 0, "o": 2, "military": True},
+            {"text": ["y treinta", "y cuatro"], "h": 0, "o": 2},
+        ],
+        "35": [
+            {"text": ["treinta", "y cinco"], "h": 0, "o": 2, "military": True},
+            {"text": ["y treinta", "y cinco"], "h": 0, "o": 2},
+            {"text": ["menos veinti", "cinco"], "h": 1, "o": 2},
+        ],
+        "36": [
+            {"text": ["treinta", "y seis"], "h": 0, "o": 2, "military": True},
+            {"text": ["y treinta", "y seis"], "h": 0, "o": 2},
+        ],
+        "37": [
+            {"text": ["treinta", "y siete"], "h": 0, "o": 2, "military": True},
+            {"text": ["y treinta", "y siete"], "h": 0, "o": 2},
+        ],
+        "38": [
+            {"text": ["treinta", "y ocho"], "h": 0, "o": 2, "military": True},
+            {"text": ["y treinta", "y ocho"], "h": 0, "o": 2},
+        ],
+        "39": [
+            {"text": ["treinta", "y nueve"], "h": 0, "o": 2, "military": True},
+            {"text": ["y treinta", "y nueve"], "h": 0, "o": 2},
+        ],
+        "40": [
+            {"text": ["cuarenta"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuarenta"], "h": 0, "o": 2},
+            {"text": ["menos veinte"], "h": 1, "o": 2},
+        ],
+        "41": [
+            {"text": ["cuarenta", "y uno"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuarenta", "y uno"], "h": 0, "o": 2},
+        ],
+        "42": [
+            {"text": ["cuarenta", "y dos"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuarenta", "y dos"], "h": 0, "o": 2},
+        ],
+        "43": [
+            {"text": ["cuarenta", "y tres"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuarenta", "y tres"], "h": 0, "o": 2},
+        ],
+        "44": [
+            {"text": ["cuarenta", "y cuatro"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuarenta", "y cuatro"], "h": 0, "o": 2},
+        ],
+        "45": [
+            {"text": ["cuarenta", "y cinco"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuarenta", "y cinco"], "h": 0, "o": 2},
+            {"text": ["menos cuarto"], "h": 1, "o": 2},
+        ],
+        "46": [
+            {"text": ["cuarenta", "y seis"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuarenta", "y seis"], "h": 0, "o": 2},
+        ],
+        "47": [
+            {"text": ["cuarenta", "y siete"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuarenta", "y siete"], "h": 0, "o": 2},
+        ],
+        "48": [
+            {"text": ["cuarenta", "y ocho"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuarenta", "y ocho"], "h": 0, "o": 2},
+        ],
+        "49": [
+            {"text": ["cuarenta", "y nueve"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cuarenta", "y nueve"], "h": 0, "o": 2},
+        ],
+        "50": [
+            {"text": ["cincuenta"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cincuenta"], "h": 0, "o": 2},
+            {"text": ["menos diez"], "h": 1, "o": 2},
+        ],
+        "51": [
+            {"text": ["cincuenta", "y uno"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cincuenta", "y uno"], "h": 0, "o": 2},
+            {"text": ["menos nueve"], "h": 1, "o": 2},
+        ],
+        "52": [
+            {"text": ["cincuenta", "y dos"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cincuenta", "y dos"], "h": 0, "o": 2},
+            {"text": ["menos ocho"], "h": 1, "o": 2},
+        ],
+        "53": [
+            {"text": ["cincuenta", "y tres"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cincuenta", "y tres"], "h": 0, "o": 2},
+            {"text": ["menos siete"], "h": 1, "o": 2},
+        ],
+        "54": [
+            {"text": ["cincuenta", "y cuatro"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cincuenta", "y cuatro"], "h": 0, "o": 2},
+            {"text": ["menos seis"], "h": 1, "o": 2},
+        ],
+        "55": [
+            {"text": ["cincuenta", "y cinco"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cincuenta", "y cinco"], "h": 0, "o": 2},
+            {"text": ["menos cinco"], "h": 1, "o": 2},
+        ],
+        "56": [
+            {"text": ["cincuenta", "y seis"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cincuenta", "y seis"], "h": 0, "o": 2},
+            {"text": ["menos cuatro"], "h": 1, "o": 2},
+        ],
+        "57": [
+            {"text": ["cincuenta", "y siete"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cincuenta", "y siete"], "h": 0, "o": 2},
+            {"text": ["menos tres"], "h": 1, "o": 2},
+        ],
+        "58": [
+            {"text": ["cincuenta", "y ocho"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cincuenta", "y ocho"], "h": 0, "o": 2},
+            {"text": ["menos dos"], "h": 1, "o": 2},
+        ],
+        "59": [
+            {"text": ["cincuenta", "y nueve"], "h": 0, "o": 2, "military": True},
+            {"text": ["y cincuenta", "y nueve"], "h": 0, "o": 2},
+            {"text": ["menos un", "minuto"], "h": 1, "o": 2},
+        ],
+    },
+    "pt-BR": {
+        "0": [
+            {"text": [], "h": 0, "o": 2, "military": True},
+            {"text": [], "h": 0, "o": 2},
+            {"text": ["em ponto"], "h": 0, "o": 2},
+        ],
+        "1": [
+            {"text": ["e um"], "h": 0, "o": 2, "military": True},
+            {"text": ["e um"], "h": 0, "o": 2},
+        ],
+        "2": [
+            {"text": ["e dois"], "h": 0, "o": 2, "military": True},
+            {"text": ["e dois"], "h": 0, "o": 2},
+        ],
+        "3": [
+            {"text": ["e três"], "h": 0, "o": 2, "military": True},
+            {"text": ["e três"], "h": 0, "o": 2},
+        ],
+        "4": [
+            {"text": ["e quatro"], "h": 0, "o": 2, "military": True},
+            {"text": ["e quatro"], "h": 0, "o": 2},
+        ],
+        "5": [
+            {"text": ["e cinco"], "h": 0, "o": 2, "military": True},
+            {"text": ["e cinco"], "h": 0, "o": 2},
+        ],
+        "6": [
+            {"text": ["e seis"], "h": 0, "o": 2, "military": True},
+            {"text": ["e seis"], "h": 0, "o": 2},
+        ],
+        "7": [
+            {"text": ["e sete"], "h": 0, "o": 2, "military": True},
+            {"text": ["e sete"], "h": 0, "o": 2},
+        ],
+        "8": [
+            {"text": ["e oito"], "h": 0, "o": 2, "military": True},
+            {"text": ["e oito"], "h": 0, "o": 2},
+        ],
+        "9": [
+            {"text": ["e nove"], "h": 0, "o": 2, "military": True},
+            {"text": ["e nove"], "h": 0, "o": 2},
+        ],
+        "10": [
+            {"text": ["e dez"], "h": 0, "o": 2, "military": True},
+        ],
+        "11": [
+            {"text": ["e onze"], "h": 0, "o": 2, "military": True},
+        ],
+        "12": [
+            {"text": ["e doze"], "h": 0, "o": 2, "military": True},
+        ],
+        "13": [
+            {"text": ["e treze"], "h": 0, "o": 2, "military": True},
+        ],
+        "14": [
+            {"text": ["e quatorze"], "h": 0, "o": 2, "military": True},
+        ],
+        "15": [
+            {"text": ["e quinze"], "h": 0, "o": 2, "military": True},
+        ],
+        "16": [
+            {"text": ["e dezesseis"], "h": 0, "o": 2, "military": True},
+        ],
+        "17": [
+            {"text": ["e dezessete"], "h": 0, "o": 2, "military": True},
+        ],
+        "18": [
+            {"text": ["e dezoito"], "h": 0, "o": 2, "military": True},
+        ],
+        "19": [
+            {"text": ["e dezenove"], "h": 0, "o": 2, "military": True},
+        ],
+        "20": [
+            {"text": ["e vinte"], "h": 0, "o": 2, "military": True},
+        ],
+        "21": [
+            {"text": ["e vinte e um"], "h": 0, "o": 2, "military": True},
+        ],
+        "22": [
+            {"text": ["e vinte", "e dois"], "h": 0, "o": 2, "military": True},
+        ],
+        "23": [
+            {"text": ["e vinte", "e três"], "h": 0, "o": 2, "military": True},
+        ],
+        "24": [
+            {"text": ["e vinte", "e quatro"], "h": 0, "o": 2, "military": True},
+        ],
+        "25": [
+            {"text": ["e vinte", "e cinco"], "h": 0, "o": 2, "military": True},
+        ],
+        "26": [
+            {"text": ["e vinte", "e seis"], "h": 0, "o": 2, "military": True},
+        ],
+        "27": [
+            {"text": ["e vinte", "e sete"], "h": 0, "o": 2, "military": True},
+        ],
+        "28": [
+            {"text": ["e vinte", "e oito"], "h": 0, "o": 2, "military": True},
+        ],
+        "29": [
+            {"text": ["e vinte", "e nove"], "h": 0, "o": 2, "military": True},
+        ],
+        "30": [
+            {"text": ["e trinta"], "h": 0, "o": 2, "military": True},
+            {"text": ["e trinta"], "h": 0, "o": 2},
+            {"text": ["e meia"], "h": 0, "o": 2},
+        ],
+        "31": [
+            {"text": ["e trinta", "e um"], "h": 0, "o": 2, "military": True},
+        ],
+        "32": [
+            {"text": ["e trinta", "e dois"], "h": 0, "o": 2, "military": True},
+        ],
+        "33": [
+            {"text": ["e trinta", "e três"], "h": 0, "o": 2, "military": True},
+        ],
+        "34": [
+            {"text": ["e trinta", "e quatro"], "h": 0, "o": 2, "military": True},
+        ],
+        "35": [
+            {"text": ["e trinta", "e cinco"], "h": 0, "o": 2, "military": True},
+        ],
+        "36": [
+            {"text": ["e trinta", "e seis"], "h": 0, "o": 2, "military": True},
+        ],
+        "37": [
+            {"text": ["e trinta", "e sete"], "h": 0, "o": 2, "military": True},
+        ],
+        "38": [
+            {"text": ["e trinta", "e oito"], "h": 0, "o": 2, "military": True},
+        ],
+        "39": [
+            {"text": ["e trinta", "e nove"], "h": 0, "o": 2, "military": True},
+        ],
+        "40": [
+            {"text": ["e quarenta"], "h": 0, "o": 2, "military": True},
+            {"text": ["vinte para", "as"], "h": 1, "o": 1},
+        ],
+        "41": [
+            {"text": ["e quarenta", "e um"], "h": 0, "o": 2, "military": True},
+        ],
+        "42": [
+            {"text": ["e quarenta", "e dois"], "h": 0, "o": 2, "military": True},
+        ],
+        "43": [
+            {"text": ["e quarenta", "e três"], "h": 0, "o": 2, "military": True},
+        ],
+        "44": [
+            {"text": ["e quarenta", "e quatro"], "h": 0, "o": 2, "military": True},
+        ],
+        "45": [
+            {"text": ["e quarenta", "e cinco"], "h": 0, "o": 2, "military": True},
+            {"text": ["quinze para", "as"], "h": 1, "o": 1},
+        ],
+        "46": [
+            {"text": ["e quarenta", "e seis"], "h": 0, "o": 2, "military": True},
+        ],
+        "47": [
+            {"text": ["e quarenta", "e sete"], "h": 0, "o": 2, "military": True},
+        ],
+        "48": [
+            {"text": ["e quarenta", "e oito"], "h": 0, "o": 2, "military": True},
+        ],
+        "49": [
+            {"text": ["e quarenta", "e nove"], "h": 0, "o": 2, "military": True},
+        ],
+        "50": [
+            {"text": ["e cinquenta"], "h": 0, "o": 2, "military": True},
+            {"text": ["dez para", "as"], "h": 1, "o": 1},
+        ],
+        "51": [
+            {"text": ["e cinquenta", "e um"], "h": 0, "o": 2, "military": True},
+        ],
+        "52": [
+            {"text": ["e cinquenta", "e dois"], "h": 0, "o": 2, "military": True},
+        ],
+        "53": [
+            {"text": ["e cinquenta", "e três"], "h": 0, "o": 2, "military": True},
+        ],
+        "54": [
+            {"text": ["e cinquenta", "e quatro"], "h": 0, "o": 2, "military": True},
+        ],
+        "55": [
+            {"text": ["e cinquenta", "e cinco"], "h": 0, "o": 2, "military": True},
+            {"text": ["cinco para", "as"], "h": 1, "o": 1},
+        ],
+        "56": [
+            {"text": ["e cinquenta", "e seis"], "h": 0, "o": 2, "military": True},
+        ],
+        "57": [
+            {"text": ["e cinquenta", "e sete"], "h": 0, "o": 2, "military": True},
+        ],
+        "58": [
+            {"text": ["e cinquenta", "e oito"], "h": 0, "o": 2, "military": True},
+        ],
+        "59": [
+            {"text": ["e cinquenta", "e nove"], "h": 0, "o": 2, "military": True},
+        ],
+    },
+    "it-IT": {
+        "0": [
+            {"text": [], "h": 0, "o": 2, "military": True},
+            {"text": [], "h": 0, "o": 2},
+            {"text": ["in punto"], "h": 0, "o": 2},
+        ],
+        "1": [
+            {"text": ["e un minuto"], "h": 0, "o": 2, "military": True},
+            {"text": ["e un minuto"], "h": 0, "o": 2},
+        ],
+        "2": [
+            {"text": ["e due"], "h": 0, "o": 2, "military": True},
+            {"text": ["e due"], "h": 0, "o": 2},
+        ],
+        "3": [
+            {"text": ["e tre"], "h": 0, "o": 2, "military": True},
+            {"text": ["e tre"], "h": 0, "o": 2},
+        ],
+        "4": [
+            {"text": ["e quattro"], "h": 0, "o": 2, "military": True},
+            {"text": ["e quattro"], "h": 0, "o": 2},
+        ],
+        "5": [
+            {"text": ["e cinque"], "h": 0, "o": 2, "military": True},
+            {"text": ["e cinque"], "h": 0, "o": 2},
+        ],
+        "6": [
+            {"text": ["e sei"], "h": 0, "o": 2, "military": True},
+            {"text": ["e sei"], "h": 0, "o": 2},
+        ],
+        "7": [
+            {"text": ["e sette"], "h": 0, "o": 2, "military": True},
+            {"text": ["e sette"], "h": 0, "o": 2},
+        ],
+        "8": [
+            {"text": ["e otto"], "h": 0, "o": 2, "military": True},
+            {"text": ["e otto"], "h": 0, "o": 2},
+        ],
+        "9": [
+            {"text": ["e nove"], "h": 0, "o": 2, "military": True},
+            {"text": ["e nove"], "h": 0, "o": 2},
+        ],
+        "10": [
+            {"text": ["e dieci"], "h": 0, "o": 2, "military": True},
+        ],
+        "11": [
+            {"text": ["e undici"], "h": 0, "o": 2, "military": True},
+        ],
+        "12": [
+            {"text": ["e dodici"], "h": 0, "o": 2, "military": True},
+        ],
+        "13": [
+            {"text": ["e tredici"], "h": 0, "o": 2, "military": True},
+        ],
+        "14": [
+            {"text": ["e", "quattordici"], "h": 0, "o": 2, "military": True},
+        ],
+        "15": [
+            {"text": ["e quindici"], "h": 0, "o": 2, "military": True},
+            {"text": ["e quindici"], "h": 0, "o": 2},
+            {"text": ["e un quarto"], "h": 0, "o": 2},
+        ],
+        "16": [
+            {"text": ["e sedici"], "h": 0, "o": 2, "military": True},
+        ],
+        "17": [
+            {"text": ["e", "diciassette"], "h": 0, "o": 2, "military": True},
+        ],
+        "18": [
+            {"text": ["e diciotto"], "h": 0, "o": 2, "military": True},
+        ],
+        "19": [
+            {"text": ["e", "diciannove"], "h": 0, "o": 2, "military": True},
+        ],
+        "20": [
+            {"text": ["e venti"], "h": 0, "o": 2, "military": True},
+        ],
+        "21": [
+            {"text": ["e ventuno"], "h": 0, "o": 2, "military": True},
+        ],
+        "22": [
+            {"text": ["e ventidue"], "h": 0, "o": 2, "military": True},
+        ],
+        "23": [
+            {"text": ["e ventitré"], "h": 0, "o": 2, "military": True},
+        ],
+        "24": [
+            {"text": ["e venti", "quattro"], "h": 0, "o": 2, "military": True},
+        ],
+        "25": [
+            {"text": ["e venti", "cinque"], "h": 0, "o": 2, "military": True},
+        ],
+        "26": [
+            {"text": ["e ventisei"], "h": 0, "o": 2, "military": True},
+        ],
+        "27": [
+            {"text": ["e ventisette"], "h": 0, "o": 2, "military": True},
+        ],
+        "28": [
+            {"text": ["e ventotto"], "h": 0, "o": 2, "military": True},
+        ],
+        "29": [
+            {"text": ["e ventinove"], "h": 0, "o": 2, "military": True},
+        ],
+        "30": [
+            {"text": ["e trenta"], "h": 0, "o": 2, "military": True},
+            {"text": ["e trenta"], "h": 0, "o": 2},
+            {"text": ["e mezza"], "h": 0, "o": 2},
+        ],
+        "31": [
+            {"text": ["e trentuno"], "h": 0, "o": 2, "military": True},
+        ],
+        "32": [
+            {"text": ["e trentadue"], "h": 0, "o": 2, "military": True},
+        ],
+        "33": [
+            {"text": ["e trentatré"], "h": 0, "o": 2, "military": True},
+        ],
+        "34": [
+            {"text": ["e trenta", "quattro"], "h": 0, "o": 2, "military": True},
+        ],
+        "35": [
+            {"text": ["e trenta", "cinque"], "h": 0, "o": 2, "military": True},
+            {"text": ["meno venti", "cinque"], "h": 1, "o": 2},
+        ],
+        "36": [
+            {"text": ["e trentasei"], "h": 0, "o": 2, "military": True},
+        ],
+        "37": [
+            {"text": ["e trenta", "sette"], "h": 0, "o": 2, "military": True},
+        ],
+        "38": [
+            {"text": ["e trentotto"], "h": 0, "o": 2, "military": True},
+        ],
+        "39": [
+            {"text": ["e trenta", "nove"], "h": 0, "o": 2, "military": True},
+        ],
+        "40": [
+            {"text": ["e quaranta"], "h": 0, "o": 2, "military": True},
+            {"text": ["meno venti"], "h": 1, "o": 2},
+        ],
+        "41": [
+            {"text": ["e quaran", "tuno"], "h": 0, "o": 2, "military": True},
+        ],
+        "42": [
+            {"text": ["e quaranta", "due"], "h": 0, "o": 2, "military": True},
+        ],
+        "43": [
+            {"text": ["e quaranta", "tré"], "h": 0, "o": 2, "military": True},
+        ],
+        "44": [
+            {"text": ["e quaranta", "quattro"], "h": 0, "o": 2, "military": True},
+        ],
+        "45": [
+            {"text": ["e quaranta", "cinque"], "h": 0, "o": 2, "military": True},
+            {"text": ["meno", "un quarto"], "h": 1, "o": 2},
+        ],
+        "46": [
+            {"text": ["e quaranta", "sei"], "h": 0, "o": 2, "military": True},
+        ],
+        "47": [
+            {"text": ["e quaranta", "sette"], "h": 0, "o": 2, "military": True},
+        ],
+        "48": [
+            {"text": ["e quaran", "totto"], "h": 0, "o": 2, "military": True},
+        ],
+        "49": [
+            {"text": ["e quaranta", "nove"], "h": 0, "o": 2, "military": True},
+        ],
+        "50": [
+            {"text": ["e cinquanta"], "h": 0, "o": 2, "military": True},
+            {"text": ["meno dieci"], "h": 1, "o": 2},
+        ],
+        "51": [
+            {"text": ["e cinquan", "tuno"], "h": 0, "o": 2, "military": True},
+        ],
+        "52": [
+            {"text": ["e cinquanta", "due"], "h": 0, "o": 2, "military": True},
+        ],
+        "53": [
+            {"text": ["e cinquanta", "tré"], "h": 0, "o": 2, "military": True},
+        ],
+        "54": [
+            {"text": ["e cinquanta", "quattro"], "h": 0, "o": 2, "military": True},
+        ],
+        "55": [
+            {"text": ["e cinquanta", "cinque"], "h": 0, "o": 2, "military": True},
+            {"text": ["meno cinque"], "h": 1, "o": 2},
+        ],
+        "56": [
+            {"text": ["e cinquanta", "sei"], "h": 0, "o": 2, "military": True},
+        ],
+        "57": [
+            {"text": ["e cinquanta", "sette"], "h": 0, "o": 2, "military": True},
+        ],
+        "58": [
+            {"text": ["e cinquan", "totto"], "h": 0, "o": 2, "military": True},
+        ],
+        "59": [
+            {"text": ["e cinquanta", "nove"], "h": 0, "o": 2, "military": True},
+        ],
+    },
 }
 
 timeOfDayObj = {
@@ -421,6 +1286,40 @@ timeOfDayObj = {
         {"hourMin": 12, "hourMax": 13, "text": [[]]},
         {"hourMin": 13, "hourMax": 18, "text": [["de l'après-midi"]]},
         {"hourMin": 18, "hourMax": 24, "text": [["du soir"]]},
+    ],
+    "de-DE": [
+        {"hourMin": 0, "hourMax": 5, "text": [["nachts"]]},
+        {"hourMin": 5, "hourMax": 10, "text": [["morgens"]]},
+        {"hourMin": 10, "hourMax": 12, "text": [["vormittags"]]},
+        {"hourMin": 12, "hourMax": 13, "text": [["mittags"]]},
+        {"hourMin": 13, "hourMax": 18, "text": [["nachmittags"]]},
+        {"hourMin": 18, "hourMax": 23, "text": [["abends"]]},
+        {"hourMin": 23, "hourMax": 24, "text": [["nachts"]]},
+    ],
+    "es-ES": [
+        {"hourMin": 0, "hourMax": 1, "text": [["de la noche"], ["de la madrugada"]]},
+        {"hourMin": 1, "hourMax": 6, "text": [["de la madrugada"]]},
+        {"hourMin": 6, "hourMax": 12, "text": [["de la mañana"]]},
+        {"hourMin": 12, "hourMax": 13, "text": [["del mediodía"]]},
+        {"hourMin": 13, "hourMax": 21, "text": [["de la tarde"]]},
+        {"hourMin": 21, "hourMax": 24, "text": [["de la noche"]]},
+    ],
+    "pt-BR": [
+        {"hourMin": 0, "hourMax": 1, "text": [[]]},
+        {"hourMin": 1, "hourMax": 6, "text": [["da madrugada"]]},
+        {"hourMin": 6, "hourMax": 12, "text": [["da manhã"]]},
+        {"hourMin": 12, "hourMax": 13, "text": [[]]},
+        {"hourMin": 13, "hourMax": 18, "text": [["da tarde"]]},
+        {"hourMin": 18, "hourMax": 24, "text": [["da noite"]]},
+    ],
+    "it-IT": [
+        {"hourMin": 0, "hourMax": 1, "text": [[]]},
+        {"hourMin": 1, "hourMax": 4, "text": [["di notte"], ["del mattino"]]},
+        {"hourMin": 4, "hourMax": 5, "text": [["del mattino"], ["di notte"]]},
+        {"hourMin": 5, "hourMax": 12, "text": [["del mattino"]]},
+        {"hourMin": 12, "hourMax": 13, "text": [[]]},
+        {"hourMin": 13, "hourMax": 18, "text": [["del pomeriggio"]]},
+        {"hourMin": 18, "hourMax": 24, "text": [["di sera"]]},
     ],
 }
 
@@ -480,6 +1379,110 @@ hoursObj = {
         "21": ["neuf heures", "vingt-et-une"],
         "22": ["dix heures", "vingt-deux"],
         "23": ["onze heures", "vingt-trois"],
+    },
+    "de-DE": {
+        "0": ["zwölf", "zwölf Uhr", "null Uhr"],
+        "1": ["eins", "ein Uhr", "ein Uhr"],
+        "2": ["zwei", "zwei Uhr", "zwei Uhr"],
+        "3": ["drei", "drei Uhr", "drei Uhr"],
+        "4": ["vier", "vier Uhr", "vier Uhr"],
+        "5": ["fünf", "fünf Uhr", "fünf Uhr"],
+        "6": ["sechs", "sechs Uhr", "sechs Uhr"],
+        "7": ["sieben", "sieben Uhr", "sieben Uhr"],
+        "8": ["acht", "acht Uhr", "acht Uhr"],
+        "9": ["neun", "neun Uhr", "neun Uhr"],
+        "10": ["zehn", "zehn Uhr", "zehn Uhr"],
+        "11": ["elf", "elf Uhr", "elf Uhr"],
+        "12": ["zwölf", "zwölf Uhr", "zwölf Uhr"],
+        "13": ["eins", "ein Uhr", "dreizehn Uhr"],
+        "14": ["zwei", "zwei Uhr", "vierzehn Uhr"],
+        "15": ["drei", "drei Uhr", "fünfzehn Uhr"],
+        "16": ["vier", "vier Uhr", "sechzehn Uhr"],
+        "17": ["fünf", "fünf Uhr", "siebzehn Uhr"],
+        "18": ["sechs", "sechs Uhr", "achtzehn Uhr"],
+        "19": ["sieben", "sieben Uhr", "neunzehn Uhr"],
+        "20": ["acht", "acht Uhr", "zwanzig Uhr"],
+        "21": ["neun", "neun Uhr", "einund|zwanzig Uhr"],
+        "22": ["zehn", "zehn Uhr", "zweiund|zwanzig Uhr"],
+        "23": ["elf", "elf Uhr", "dreiund|zwanzig Uhr"],
+    },
+    "es-ES": {
+        "0": ["las doce", "cero"],
+        "1": ["la una", "una"],
+        "2": ["las dos", "dos"],
+        "3": ["las tres", "tres"],
+        "4": ["las cuatro", "cuatro"],
+        "5": ["las cinco", "cinco"],
+        "6": ["las seis", "seis"],
+        "7": ["las siete", "siete"],
+        "8": ["las ocho", "ocho"],
+        "9": ["las nueve", "nueve"],
+        "10": ["las diez", "diez"],
+        "11": ["las once", "once"],
+        "12": ["las doce", "doce"],
+        "13": ["la una", "trece"],
+        "14": ["las dos", "catorce"],
+        "15": ["las tres", "quince"],
+        "16": ["las cuatro", "dieciséis"],
+        "17": ["las cinco", "diecisiete"],
+        "18": ["las seis", "dieciocho"],
+        "19": ["las siete", "diecinueve"],
+        "20": ["las ocho", "veinte"],
+        "21": ["las nueve", "veintiuna"],
+        "22": ["las diez", "veintidós"],
+        "23": ["las once", "veintitrés"],
+    },
+    "pt-BR": {
+        "0": ["meia-noite", "zero"],
+        "1": ["uma", "uma"],
+        "2": ["duas", "duas"],
+        "3": ["três", "três"],
+        "4": ["quatro", "quatro"],
+        "5": ["cinco", "cinco"],
+        "6": ["seis", "seis"],
+        "7": ["sete", "sete"],
+        "8": ["oito", "oito"],
+        "9": ["nove", "nove"],
+        "10": ["dez", "dez"],
+        "11": ["onze", "onze"],
+        "12": ["meio-dia", "doze"],
+        "13": ["uma", "treze"],
+        "14": ["duas", "quatorze"],
+        "15": ["três", "quinze"],
+        "16": ["quatro", "dezesseis"],
+        "17": ["cinco", "dezessete"],
+        "18": ["seis", "dezoito"],
+        "19": ["sete", "dezenove"],
+        "20": ["oito", "vinte"],
+        "21": ["nove", "vinte e uma"],
+        "22": ["dez", "vinte e duas"],
+        "23": ["onze", "vinte e três"],
+    },
+    "it-IT": {
+        "0": ["mezzanotte", "zero"],
+        "1": ["l'una", "l'una"],
+        "2": ["le due", "le due"],
+        "3": ["le tre", "le tre"],
+        "4": ["le quattro", "le quattro"],
+        "5": ["le cinque", "le cinque"],
+        "6": ["le sei", "le sei"],
+        "7": ["le sette", "le sette"],
+        "8": ["le otto", "le otto"],
+        "9": ["le nove", "le nove"],
+        "10": ["le dieci", "le dieci"],
+        "11": ["le undici", "le undici"],
+        "12": ["mezzogiorno", "le dodici"],
+        "13": ["l'una", "le tredici"],
+        "14": ["le due", "le quattordici"],
+        "15": ["le tre", "le quindici"],
+        "16": ["le quattro", "le sedici"],
+        "17": ["le cinque", "le diciassette"],
+        "18": ["le sei", "le diciotto"],
+        "19": ["le sette", "le diciannove"],
+        "20": ["le otto", "le venti"],
+        "21": ["le nove", "le ventuno"],
+        "22": ["le dieci", "le ventidue"],
+        "23": ["le undici", "le ventitré"],
     },
 }
 
@@ -541,6 +1544,114 @@ gameOfThronesObj = {
         "22": "",
         "23": "",
     },
+    "de-DE": {
+        "stem": "",
+        "0": "",
+        "1": "",
+        "2": "",
+        "3": "",
+        "4": "",
+        "5": "",
+        "6": "",
+        "7": "",
+        "8": "",
+        "9": "",
+        "10": "",
+        "11": "",
+        "12": "",
+        "13": "",
+        "14": "",
+        "15": "",
+        "16": "",
+        "17": "",
+        "18": "",
+        "19": "",
+        "20": "",
+        "21": "",
+        "22": "",
+        "23": "",
+    },
+    "es-ES": {
+        "stem": "",
+        "0": "",
+        "1": "",
+        "2": "",
+        "3": "",
+        "4": "",
+        "5": "",
+        "6": "",
+        "7": "",
+        "8": "",
+        "9": "",
+        "10": "",
+        "11": "",
+        "12": "",
+        "13": "",
+        "14": "",
+        "15": "",
+        "16": "",
+        "17": "",
+        "18": "",
+        "19": "",
+        "20": "",
+        "21": "",
+        "22": "",
+        "23": "",
+    },
+    "pt-BR": {
+        "stem": "",
+        "0": "",
+        "1": "",
+        "2": "",
+        "3": "",
+        "4": "",
+        "5": "",
+        "6": "",
+        "7": "",
+        "8": "",
+        "9": "",
+        "10": "",
+        "11": "",
+        "12": "",
+        "13": "",
+        "14": "",
+        "15": "",
+        "16": "",
+        "17": "",
+        "18": "",
+        "19": "",
+        "20": "",
+        "21": "",
+        "22": "",
+        "23": "",
+    },
+    "it-IT": {
+        "stem": "",
+        "0": "",
+        "1": "",
+        "2": "",
+        "3": "",
+        "4": "",
+        "5": "",
+        "6": "",
+        "7": "",
+        "8": "",
+        "9": "",
+        "10": "",
+        "11": "",
+        "12": "",
+        "13": "",
+        "14": "",
+        "15": "",
+        "16": "",
+        "17": "",
+        "18": "",
+        "19": "",
+        "20": "",
+        "21": "",
+        "22": "",
+        "23": "",
+    },
 }
 
 specialObj = {
@@ -556,6 +1667,39 @@ specialObj = {
         "0:30": [["minuit", "et demi"], ["minuit", "trente"]],
         "12:0": [["midi"], ["midi", "pile"]],
         "12:30": [["midi", "et demi"], ["midi", "trente"]],
+    },
+    "de-DE": {
+        "0:0": [["Mitternacht"], ["null Uhr"], ["zwölf Uhr"]],
+        "12:0": [["zwölf Uhr"], ["Mittag"], ["Punkt", "zwölf"]],
+    },
+    "es-ES": {
+        "0:0": [["las doce"], ["medianoche"], ["las doce", "en punto"]],
+        "12:0": [["las doce"], ["mediodía"], ["las doce", "en punto"]],
+    },
+    "pt-BR": {
+        "0:0": [["meia-noite"], ["meia-noite"], ["meia-noite", "em ponto"]],
+        "0:40": [["meia-noite", "e quarenta"], ["vinte para", "a uma"]],
+        "0:45": [["meia-noite", "e quarenta", "e cinco"], ["quinze para", "a uma"]],
+        "0:50": [["meia-noite", "e cinquenta"], ["dez para", "a uma"]],
+        "0:55": [["meia-noite", "e cinquenta", "e cinco"], ["cinco para", "a uma"]],
+        "11:40": [["onze", "e quarenta"], ["vinte para", "o meio-dia"]],
+        "11:45": [["onze", "e quarenta", "e cinco"], ["quinze para", "o meio-dia"]],
+        "11:50": [["onze", "e cinquenta"], ["dez para", "o meio-dia"]],
+        "11:55": [["onze", "e cinquenta", "e cinco"], ["cinco para", "o meio-dia"]],
+        "12:0": [["meio-dia"], ["meio-dia"], ["meio-dia", "em ponto"]],
+        "12:40": [["meio-dia", "e quarenta"], ["vinte para", "a uma"]],
+        "12:45": [["meio-dia", "e quarenta", "e cinco"], ["quinze para", "a uma"]],
+        "12:50": [["meio-dia", "e cinquenta"], ["dez para", "a uma"]],
+        "12:55": [["meio-dia", "e cinquenta", "e cinco"], ["cinco para", "a uma"]],
+        "23:40": [["onze", "e quarenta"], ["vinte para", "a meia-noite"]],
+        "23:45": [["onze", "e quarenta", "e cinco"], ["quinze para", "a meia-noite"]],
+        "23:50": [["onze", "e cinquenta"], ["dez para", "a meia-noite"]],
+        "23:55": [["onze", "e cinquenta", "e cinco"], ["cinco para", "a meia-noite"]],
+    },
+    "it-IT": {
+        "0:0": [["mezzanotte"], ["mezzanotte"], ["mezzanotte", "in punto"]],
+        "12:0": [["mezzogiorno"], ["mezzogiorno"], ["mezzogiorno", "in punto"]],
+        "12:30": [["mezzogiorno", "e mezzo"], ["mezzogiorno", "e trenta"]],
     },
 }
 
@@ -589,8 +1733,11 @@ dialectObj = {
         "subtitleCascade": True,
         "militaryPad": "zero ",
         "militaryNoun": [],
+        "militarySingularHours": [],
         "ampm": ["AM", "PM"],
         "dayPartFollowsHourWord": False,
+        "additiveHourIndex": 0,
+        "upperFixups": [],
     },
     "fr-FR": {
         "subtitleFont": "tom-thumb",
@@ -598,8 +1745,59 @@ dialectObj = {
         "subtitleCascade": False,
         "militaryPad": "",
         "militaryNoun": ["heure", "heures"],
+        "militarySingularHours": [0, 1],
         "ampm": [],
         "dayPartFollowsHourWord": True,
+        "additiveHourIndex": 0,
+        "upperFixups": [],
+    },
+    "de-DE": {
+        "subtitleFont": "tom-thumb",
+        "subtitleHeight": 8,
+        "subtitleCascade": False,
+        "militaryPad": "",
+        "militaryNoun": [],
+        "militarySingularHours": [],
+        "ampm": [],
+        "dayPartFollowsHourWord": False,
+        "additiveHourIndex": 1,
+        "upperFixups": [["ß", "SS"]],
+    },
+    "es-ES": {
+        "subtitleFont": "tom-thumb",
+        "subtitleHeight": 8,
+        "subtitleCascade": False,
+        "militaryPad": "",
+        "militaryNoun": ["hora", "horas"],
+        "militarySingularHours": [1],
+        "ampm": [],
+        "dayPartFollowsHourWord": True,
+        "additiveHourIndex": 0,
+        "upperFixups": [],
+    },
+    "pt-BR": {
+        "subtitleFont": "tom-thumb",
+        "subtitleHeight": 8,
+        "subtitleCascade": False,
+        "militaryPad": "",
+        "militaryNoun": ["hora", "horas"],
+        "militarySingularHours": [1],
+        "ampm": [],
+        "dayPartFollowsHourWord": True,
+        "additiveHourIndex": 0,
+        "upperFixups": [],
+    },
+    "it-IT": {
+        "subtitleFont": "tom-thumb",
+        "subtitleHeight": 8,
+        "subtitleCascade": False,
+        "militaryPad": "",
+        "militaryNoun": [],
+        "militarySingularHours": [],
+        "ampm": [],
+        "dayPartFollowsHourWord": True,
+        "additiveHourIndex": 0,
+        "upperFixups": [],
     },
 }
 
@@ -611,17 +1809,21 @@ def military_time(hour, min, hours, minutes, rules):
     if rules["militaryPad"] and hour < 10 and hour > 0:
         hourText += rules["militaryPad"]
     hourText += hours[str(hour)][-1]
-    returnTime.append(hourText)
+
+    # "|" is an authored line break inside an hour word. German needs one --
+    # "zweiundzwanzig Uhr" is 69px on a 63px line. Words without one stay one line.
+    returnTime += hourText.split("|")
 
     if rules["militaryNoun"]:
-        returnTime.append(rules["militaryNoun"][0] if hour <= 1 else rules["militaryNoun"][1])
+        singular = hour in rules["militarySingularHours"]
+        returnTime.append(rules["militaryNoun"][0] if singular else rules["militaryNoun"][1])
 
     # add minutes text
     returnTime += minutes[str(min)][0]["text"]
 
     return returnTime
 
-def display_time(hour, min, hours, minutes, special, config):
+def display_time(hour, min, hours, minutes, special, config, rules):
     returnTime = []
 
     # a time the dialect words specially (noon, midnight, "midi et demi")
@@ -635,16 +1837,19 @@ def display_time(hour, min, hours, minutes, special, config):
             return returnTime, hour
         else:
             # handle all other times
-            # get hour text options
-            thisHourText = hours[str(hour)][0]
             nextHourIndex = 0 if hour == 23 else hour + 1
-            nextHourText = hours[str(nextHourIndex)][0]
 
             # get a random entry of the minute (that isn't military time)
             minuteMinimum = 1 if min < 10 and len(minutes[str(min)]) > 1 else 0
             minuteMaximum = len(minutes[str(min)]) - 1
             minuteIndex = random.number(minuteMinimum, minuteMaximum)
             minuteObj = minutes[str(min)][minuteIndex]
+
+            # a language can need a different hour word before its hour noun than
+            # in a relative phrase -- German says "ein Uhr" but "halb eins"
+            hourSlot = rules["additiveHourIndex"] if minuteObj["o"] == 2 else 0
+            thisHourText = hours[str(hour)][hourSlot]
+            nextHourText = hours[str(nextHourIndex)][hourSlot]
 
             # format the minuteObj according to its internal rules:
             # h is whether to use the subsequent hour word
@@ -670,7 +1875,7 @@ def display_time(hour, min, hours, minutes, special, config):
 
         else:
             # add hour text
-            returnTime.append(hours[str(hour)][0])
+            returnTime.append(hours[str(hour)][rules["additiveHourIndex"]])
 
             # add minutes text
             minIndex = 1 if min < 10 and len(minutes[str(min)]) > 1 else 0  # avoid military times
@@ -701,6 +1906,15 @@ def time_of_day(hour, timeOfDay, config, rules):
                 rangeIndex = 0 if basic else random.number(0, len(timeRange["text"]) - 1)
                 returnTime += timeRange["text"][rangeIndex]
         return returnTime
+
+def to_caps(lines, rules):
+    # .upper() leaves "ß" alone, so German would read "DREIßIG"; its uppercase is "SS"
+    out = []
+    for line in lines:
+        for pair in rules["upperFixups"]:
+            line = line.replace(pair[0], pair[1])
+        out.append(line.upper())
+    return out
 
 def calculate_top_margin(showTime, subTime, littleH):
     fullHeight = 32
@@ -739,7 +1953,7 @@ def main(config):
     if config.bool("military", False):  # use Military Time
         showTime = military_time(hour, min, hours, minutes, rules)
     else:  # basic vs. surprise me
-        showTime, spokenHour = display_time(hour, min, hours, minutes, special, config)
+        showTime, spokenHour = display_time(hour, min, hours, minutes, special, config, rules)
         if rules["dayPartFollowsHourWord"]:
             dayPartHour = spokenHour
 
@@ -755,8 +1969,8 @@ def main(config):
 
     # apply lettercase styling
     if config.get("caps", "caps") == "caps":
-        showTime = [i.upper() for i in showTime]
-        subTime = [i.upper() for i in subTime]
+        showTime = to_caps(showTime, rules)
+        subTime = to_caps(subTime, rules)
 
     # render the words
     textTime = [render.Text(" " * i + s) for i, s in enumerate(showTime)]
@@ -793,6 +2007,22 @@ def get_schema():
         schema.Option(
             display = "Français (France)",
             value = "fr-FR",
+        ),
+        schema.Option(
+            display = "Deutsch (Deutschland)",
+            value = "de-DE",
+        ),
+        schema.Option(
+            display = "Español (España)",
+            value = "es-ES",
+        ),
+        schema.Option(
+            display = "Italiano (Italia)",
+            value = "it-IT",
+        ),
+        schema.Option(
+            display = "Português (Brasil)",
+            value = "pt-BR",
         ),
     ]
 

--- a/apps/wordclock/word_clock.star
+++ b/apps/wordclock/word_clock.star
@@ -1267,6 +1267,396 @@ minutesObj = {
             {"text": ["e cinquanta", "nove"], "h": 0, "o": 2, "military": True},
         ],
     },
+    "zh-CN": {
+        "0": [
+            {"text": [], "h": 0, "o": 2, "military": True},
+            {"text": [], "h": 0, "o": 2},
+            {"text": ["整"], "h": 0, "o": 2},
+        ],
+        "1": [
+            {"text": ["零一分"], "h": 0, "o": 2, "military": True},
+            {"text": ["一分"], "h": 0, "o": 2},
+        ],
+        "2": [
+            {"text": ["零二分"], "h": 0, "o": 2, "military": True},
+            {"text": ["二分"], "h": 0, "o": 2},
+        ],
+        "3": [
+            {"text": ["零三分"], "h": 0, "o": 2, "military": True},
+            {"text": ["三分"], "h": 0, "o": 2},
+        ],
+        "4": [
+            {"text": ["零四分"], "h": 0, "o": 2, "military": True},
+            {"text": ["四分"], "h": 0, "o": 2},
+        ],
+        "5": [
+            {"text": ["零五分"], "h": 0, "o": 2, "military": True},
+            {"text": ["五分"], "h": 0, "o": 2},
+        ],
+        "6": [
+            {"text": ["零六分"], "h": 0, "o": 2, "military": True},
+            {"text": ["六分"], "h": 0, "o": 2},
+        ],
+        "7": [
+            {"text": ["零七分"], "h": 0, "o": 2, "military": True},
+            {"text": ["七分"], "h": 0, "o": 2},
+        ],
+        "8": [
+            {"text": ["零八分"], "h": 0, "o": 2, "military": True},
+            {"text": ["八分"], "h": 0, "o": 2},
+        ],
+        "9": [
+            {"text": ["零九分"], "h": 0, "o": 2, "military": True},
+            {"text": ["九分"], "h": 0, "o": 2},
+        ],
+        "10": [
+            {"text": ["十分"], "h": 0, "o": 2, "military": True},
+        ],
+        "11": [
+            {"text": ["十一分"], "h": 0, "o": 2, "military": True},
+        ],
+        "12": [
+            {"text": ["十二分"], "h": 0, "o": 2, "military": True},
+        ],
+        "13": [
+            {"text": ["十三分"], "h": 0, "o": 2, "military": True},
+        ],
+        "14": [
+            {"text": ["十四分"], "h": 0, "o": 2, "military": True},
+        ],
+        "15": [
+            {"text": ["十五分"], "h": 0, "o": 2, "military": True},
+            {"text": ["一刻"], "h": 0, "o": 2},
+        ],
+        "16": [
+            {"text": ["十六分"], "h": 0, "o": 2, "military": True},
+        ],
+        "17": [
+            {"text": ["十七分"], "h": 0, "o": 2, "military": True},
+        ],
+        "18": [
+            {"text": ["十八分"], "h": 0, "o": 2, "military": True},
+        ],
+        "19": [
+            {"text": ["十九分"], "h": 0, "o": 2, "military": True},
+        ],
+        "20": [
+            {"text": ["二十分"], "h": 0, "o": 2, "military": True},
+        ],
+        "21": [
+            {"text": ["二十一分"], "h": 0, "o": 2, "military": True},
+        ],
+        "22": [
+            {"text": ["二十二分"], "h": 0, "o": 2, "military": True},
+        ],
+        "23": [
+            {"text": ["二十三分"], "h": 0, "o": 2, "military": True},
+        ],
+        "24": [
+            {"text": ["二十四分"], "h": 0, "o": 2, "military": True},
+        ],
+        "25": [
+            {"text": ["二十五分"], "h": 0, "o": 2, "military": True},
+        ],
+        "26": [
+            {"text": ["二十六分"], "h": 0, "o": 2, "military": True},
+        ],
+        "27": [
+            {"text": ["二十七分"], "h": 0, "o": 2, "military": True},
+        ],
+        "28": [
+            {"text": ["二十八分"], "h": 0, "o": 2, "military": True},
+        ],
+        "29": [
+            {"text": ["二十九分"], "h": 0, "o": 2, "military": True},
+        ],
+        "30": [
+            {"text": ["三十分"], "h": 0, "o": 2, "military": True},
+            {"text": ["半"], "h": 0, "o": 2},
+        ],
+        "31": [
+            {"text": ["三十一分"], "h": 0, "o": 2, "military": True},
+        ],
+        "32": [
+            {"text": ["三十二分"], "h": 0, "o": 2, "military": True},
+        ],
+        "33": [
+            {"text": ["三十三分"], "h": 0, "o": 2, "military": True},
+        ],
+        "34": [
+            {"text": ["三十四分"], "h": 0, "o": 2, "military": True},
+        ],
+        "35": [
+            {"text": ["三十五分"], "h": 0, "o": 2, "military": True},
+        ],
+        "36": [
+            {"text": ["三十六分"], "h": 0, "o": 2, "military": True},
+        ],
+        "37": [
+            {"text": ["三十七分"], "h": 0, "o": 2, "military": True},
+        ],
+        "38": [
+            {"text": ["三十八分"], "h": 0, "o": 2, "military": True},
+        ],
+        "39": [
+            {"text": ["三十九分"], "h": 0, "o": 2, "military": True},
+        ],
+        "40": [
+            {"text": ["四十分"], "h": 0, "o": 2, "military": True},
+        ],
+        "41": [
+            {"text": ["四十一分"], "h": 0, "o": 2, "military": True},
+        ],
+        "42": [
+            {"text": ["四十二分"], "h": 0, "o": 2, "military": True},
+        ],
+        "43": [
+            {"text": ["四十三分"], "h": 0, "o": 2, "military": True},
+        ],
+        "44": [
+            {"text": ["四十四分"], "h": 0, "o": 2, "military": True},
+        ],
+        "45": [
+            {"text": ["四十五分"], "h": 0, "o": 2, "military": True},
+            {"text": ["三刻"], "h": 0, "o": 2},
+            {"text": ["差一刻"], "h": 1, "o": 1},
+        ],
+        "46": [
+            {"text": ["四十六分"], "h": 0, "o": 2, "military": True},
+        ],
+        "47": [
+            {"text": ["四十七分"], "h": 0, "o": 2, "military": True},
+        ],
+        "48": [
+            {"text": ["四十八分"], "h": 0, "o": 2, "military": True},
+        ],
+        "49": [
+            {"text": ["四十九分"], "h": 0, "o": 2, "military": True},
+        ],
+        "50": [
+            {"text": ["五十分"], "h": 0, "o": 2, "military": True},
+        ],
+        "51": [
+            {"text": ["五十一分"], "h": 0, "o": 2, "military": True},
+        ],
+        "52": [
+            {"text": ["五十二分"], "h": 0, "o": 2, "military": True},
+        ],
+        "53": [
+            {"text": ["五十三分"], "h": 0, "o": 2, "military": True},
+        ],
+        "54": [
+            {"text": ["五十四分"], "h": 0, "o": 2, "military": True},
+        ],
+        "55": [
+            {"text": ["五十五分"], "h": 0, "o": 2, "military": True},
+        ],
+        "56": [
+            {"text": ["五十六分"], "h": 0, "o": 2, "military": True},
+        ],
+        "57": [
+            {"text": ["五十七分"], "h": 0, "o": 2, "military": True},
+        ],
+        "58": [
+            {"text": ["五十八分"], "h": 0, "o": 2, "military": True},
+        ],
+        "59": [
+            {"text": ["五十九分"], "h": 0, "o": 2, "military": True},
+        ],
+    },
+    "ja-JP": {
+        "0": [
+            {"text": [], "h": 0, "o": 2, "military": True},
+            {"text": [], "h": 0, "o": 2},
+        ],
+        "1": [
+            {"text": ["一分"], "h": 0, "o": 2, "military": True},
+            {"text": ["一分"], "h": 0, "o": 2},
+        ],
+        "2": [
+            {"text": ["二分"], "h": 0, "o": 2, "military": True},
+            {"text": ["二分"], "h": 0, "o": 2},
+        ],
+        "3": [
+            {"text": ["三分"], "h": 0, "o": 2, "military": True},
+            {"text": ["三分"], "h": 0, "o": 2},
+        ],
+        "4": [
+            {"text": ["四分"], "h": 0, "o": 2, "military": True},
+            {"text": ["四分"], "h": 0, "o": 2},
+        ],
+        "5": [
+            {"text": ["五分"], "h": 0, "o": 2, "military": True},
+            {"text": ["五分"], "h": 0, "o": 2},
+        ],
+        "6": [
+            {"text": ["六分"], "h": 0, "o": 2, "military": True},
+            {"text": ["六分"], "h": 0, "o": 2},
+        ],
+        "7": [
+            {"text": ["七分"], "h": 0, "o": 2, "military": True},
+            {"text": ["七分"], "h": 0, "o": 2},
+        ],
+        "8": [
+            {"text": ["八分"], "h": 0, "o": 2, "military": True},
+            {"text": ["八分"], "h": 0, "o": 2},
+        ],
+        "9": [
+            {"text": ["九分"], "h": 0, "o": 2, "military": True},
+            {"text": ["九分"], "h": 0, "o": 2},
+        ],
+        "10": [
+            {"text": ["十分"], "h": 0, "o": 2, "military": True},
+        ],
+        "11": [
+            {"text": ["十一分"], "h": 0, "o": 2, "military": True},
+        ],
+        "12": [
+            {"text": ["十二分"], "h": 0, "o": 2, "military": True},
+        ],
+        "13": [
+            {"text": ["十三分"], "h": 0, "o": 2, "military": True},
+        ],
+        "14": [
+            {"text": ["十四分"], "h": 0, "o": 2, "military": True},
+        ],
+        "15": [
+            {"text": ["十五分"], "h": 0, "o": 2, "military": True},
+        ],
+        "16": [
+            {"text": ["十六分"], "h": 0, "o": 2, "military": True},
+        ],
+        "17": [
+            {"text": ["十七分"], "h": 0, "o": 2, "military": True},
+        ],
+        "18": [
+            {"text": ["十八分"], "h": 0, "o": 2, "military": True},
+        ],
+        "19": [
+            {"text": ["十九分"], "h": 0, "o": 2, "military": True},
+        ],
+        "20": [
+            {"text": ["二十分"], "h": 0, "o": 2, "military": True},
+        ],
+        "21": [
+            {"text": ["二十一分"], "h": 0, "o": 2, "military": True},
+        ],
+        "22": [
+            {"text": ["二十二分"], "h": 0, "o": 2, "military": True},
+        ],
+        "23": [
+            {"text": ["二十三分"], "h": 0, "o": 2, "military": True},
+        ],
+        "24": [
+            {"text": ["二十四分"], "h": 0, "o": 2, "military": True},
+        ],
+        "25": [
+            {"text": ["二十五分"], "h": 0, "o": 2, "military": True},
+        ],
+        "26": [
+            {"text": ["二十六分"], "h": 0, "o": 2, "military": True},
+        ],
+        "27": [
+            {"text": ["二十七分"], "h": 0, "o": 2, "military": True},
+        ],
+        "28": [
+            {"text": ["二十八分"], "h": 0, "o": 2, "military": True},
+        ],
+        "29": [
+            {"text": ["二十九分"], "h": 0, "o": 2, "military": True},
+        ],
+        "30": [
+            {"text": ["三十分"], "h": 0, "o": 2, "military": True},
+            {"text": ["半"], "h": 0, "o": 2},
+        ],
+        "31": [
+            {"text": ["三十一分"], "h": 0, "o": 2, "military": True},
+        ],
+        "32": [
+            {"text": ["三十二分"], "h": 0, "o": 2, "military": True},
+        ],
+        "33": [
+            {"text": ["三十三分"], "h": 0, "o": 2, "military": True},
+        ],
+        "34": [
+            {"text": ["三十四分"], "h": 0, "o": 2, "military": True},
+        ],
+        "35": [
+            {"text": ["三十五分"], "h": 0, "o": 2, "military": True},
+        ],
+        "36": [
+            {"text": ["三十六分"], "h": 0, "o": 2, "military": True},
+        ],
+        "37": [
+            {"text": ["三十七分"], "h": 0, "o": 2, "military": True},
+        ],
+        "38": [
+            {"text": ["三十八分"], "h": 0, "o": 2, "military": True},
+        ],
+        "39": [
+            {"text": ["三十九分"], "h": 0, "o": 2, "military": True},
+        ],
+        "40": [
+            {"text": ["四十分"], "h": 0, "o": 2, "military": True},
+        ],
+        "41": [
+            {"text": ["四十一分"], "h": 0, "o": 2, "military": True},
+        ],
+        "42": [
+            {"text": ["四十二分"], "h": 0, "o": 2, "military": True},
+        ],
+        "43": [
+            {"text": ["四十三分"], "h": 0, "o": 2, "military": True},
+        ],
+        "44": [
+            {"text": ["四十四分"], "h": 0, "o": 2, "military": True},
+        ],
+        "45": [
+            {"text": ["四十五分"], "h": 0, "o": 2, "military": True},
+        ],
+        "46": [
+            {"text": ["四十六分"], "h": 0, "o": 2, "military": True},
+        ],
+        "47": [
+            {"text": ["四十七分"], "h": 0, "o": 2, "military": True},
+        ],
+        "48": [
+            {"text": ["四十八分"], "h": 0, "o": 2, "military": True},
+        ],
+        "49": [
+            {"text": ["四十九分"], "h": 0, "o": 2, "military": True},
+        ],
+        "50": [
+            {"text": ["五十分"], "h": 0, "o": 2, "military": True},
+        ],
+        "51": [
+            {"text": ["五十一分"], "h": 0, "o": 2, "military": True},
+        ],
+        "52": [
+            {"text": ["五十二分"], "h": 0, "o": 2, "military": True},
+        ],
+        "53": [
+            {"text": ["五十三分"], "h": 0, "o": 2, "military": True},
+        ],
+        "54": [
+            {"text": ["五十四分"], "h": 0, "o": 2, "military": True},
+        ],
+        "55": [
+            {"text": ["五十五分"], "h": 0, "o": 2, "military": True},
+        ],
+        "56": [
+            {"text": ["五十六分"], "h": 0, "o": 2, "military": True},
+        ],
+        "57": [
+            {"text": ["五十七分"], "h": 0, "o": 2, "military": True},
+        ],
+        "58": [
+            {"text": ["五十八分"], "h": 0, "o": 2, "military": True},
+        ],
+        "59": [
+            {"text": ["五十九分"], "h": 0, "o": 2, "military": True},
+        ],
+    },
 }
 
 timeOfDayObj = {
@@ -1321,6 +1711,8 @@ timeOfDayObj = {
         {"hourMin": 13, "hourMax": 18, "text": [["del pomeriggio"]]},
         {"hourMin": 18, "hourMax": 24, "text": [["di sera"]]},
     ],
+    "zh-CN": [],
+    "ja-JP": [],
 }
 
 hoursObj = {
@@ -1483,6 +1875,58 @@ hoursObj = {
         "21": ["le nove", "le ventuno"],
         "22": ["le dieci", "le ventidue"],
         "23": ["le undici", "le ventitré"],
+    },
+    "zh-CN": {
+        "0": ["十二点", "零点"],
+        "1": ["一点", "一点"],
+        "2": ["兩点", "兩点"],
+        "3": ["三点", "三点"],
+        "4": ["四点", "四点"],
+        "5": ["五点", "五点"],
+        "6": ["六点", "六点"],
+        "7": ["七点", "七点"],
+        "8": ["八点", "八点"],
+        "9": ["九点", "九点"],
+        "10": ["十点", "十点"],
+        "11": ["十一点", "十一点"],
+        "12": ["十二点", "十二点"],
+        "13": ["一点", "十三点"],
+        "14": ["兩点", "十四点"],
+        "15": ["三点", "十五点"],
+        "16": ["四点", "十六点"],
+        "17": ["五点", "十七点"],
+        "18": ["六点", "十八点"],
+        "19": ["七点", "十九点"],
+        "20": ["八点", "二十点"],
+        "21": ["九点", "二十一点"],
+        "22": ["十点", "二十二点"],
+        "23": ["十一点", "二十三点"],
+    },
+    "ja-JP": {
+        "0": ["十二時", "零時"],
+        "1": ["一時", "一時"],
+        "2": ["二時", "二時"],
+        "3": ["三時", "三時"],
+        "4": ["四時", "四時"],
+        "5": ["五時", "五時"],
+        "6": ["六時", "六時"],
+        "7": ["七時", "七時"],
+        "8": ["八時", "八時"],
+        "9": ["九時", "九時"],
+        "10": ["十時", "十時"],
+        "11": ["十一時", "十一時"],
+        "12": ["十二時", "十二時"],
+        "13": ["一時", "十三時"],
+        "14": ["二時", "十四時"],
+        "15": ["三時", "十五時"],
+        "16": ["四時", "十六時"],
+        "17": ["五時", "十七時"],
+        "18": ["六時", "十八時"],
+        "19": ["七時", "十九時"],
+        "20": ["八時", "二十時"],
+        "21": ["九時", "二十一時"],
+        "22": ["十時", "二十二時"],
+        "23": ["十一時", "二十三時"],
     },
 }
 
@@ -1652,6 +2096,60 @@ gameOfThronesObj = {
         "22": "",
         "23": "",
     },
+    "zh-CN": {
+        "stem": "",
+        "0": "",
+        "1": "",
+        "2": "",
+        "3": "",
+        "4": "",
+        "5": "",
+        "6": "",
+        "7": "",
+        "8": "",
+        "9": "",
+        "10": "",
+        "11": "",
+        "12": "",
+        "13": "",
+        "14": "",
+        "15": "",
+        "16": "",
+        "17": "",
+        "18": "",
+        "19": "",
+        "20": "",
+        "21": "",
+        "22": "",
+        "23": "",
+    },
+    "ja-JP": {
+        "stem": "",
+        "0": "",
+        "1": "",
+        "2": "",
+        "3": "",
+        "4": "",
+        "5": "",
+        "6": "",
+        "7": "",
+        "8": "",
+        "9": "",
+        "10": "",
+        "11": "",
+        "12": "",
+        "13": "",
+        "14": "",
+        "15": "",
+        "16": "",
+        "17": "",
+        "18": "",
+        "19": "",
+        "20": "",
+        "21": "",
+        "22": "",
+        "23": "",
+    },
 }
 
 specialObj = {
@@ -1701,6 +2199,8 @@ specialObj = {
         "12:0": [["mezzogiorno"], ["mezzogiorno"], ["mezzogiorno", "in punto"]],
         "12:30": [["mezzogiorno", "e mezzo"], ["mezzogiorno", "e trenta"]],
     },
+    "zh-CN": {},
+    "ja-JP": {},
 }
 
 # Everything about a dialect that is behaviour rather than vocabulary.
@@ -1737,6 +2237,8 @@ dialectObj = {
         "ampm": ["AM", "PM"],
         "dayPartFollowsHourWord": False,
         "additiveHourIndex": 0,
+        "glyphs": False,
+        "lineHeight": 8,
         "upperFixups": [],
     },
     "fr-FR": {
@@ -1749,6 +2251,8 @@ dialectObj = {
         "ampm": [],
         "dayPartFollowsHourWord": True,
         "additiveHourIndex": 0,
+        "glyphs": False,
+        "lineHeight": 8,
         "upperFixups": [],
     },
     "de-DE": {
@@ -1761,6 +2265,8 @@ dialectObj = {
         "ampm": [],
         "dayPartFollowsHourWord": False,
         "additiveHourIndex": 1,
+        "glyphs": False,
+        "lineHeight": 8,
         "upperFixups": [["ß", "SS"]],
     },
     "es-ES": {
@@ -1773,6 +2279,8 @@ dialectObj = {
         "ampm": [],
         "dayPartFollowsHourWord": True,
         "additiveHourIndex": 0,
+        "glyphs": False,
+        "lineHeight": 8,
         "upperFixups": [],
     },
     "pt-BR": {
@@ -1785,6 +2293,8 @@ dialectObj = {
         "ampm": [],
         "dayPartFollowsHourWord": True,
         "additiveHourIndex": 0,
+        "glyphs": False,
+        "lineHeight": 8,
         "upperFixups": [],
     },
     "it-IT": {
@@ -1797,7 +2307,37 @@ dialectObj = {
         "ampm": [],
         "dayPartFollowsHourWord": True,
         "additiveHourIndex": 0,
+        "glyphs": False,
+        "lineHeight": 8,
         "upperFixups": [],
+    },
+    "zh-CN": {
+        "subtitleFont": "tom-thumb",
+        "subtitleHeight": 8,
+        "subtitleCascade": False,
+        "militaryPad": "",
+        "militaryNoun": [],
+        "militarySingularHours": [],
+        "ampm": [],
+        "dayPartFollowsHourWord": False,
+        "additiveHourIndex": 0,
+        "upperFixups": [],
+        "glyphs": True,
+        "lineHeight": 14,
+    },
+    "ja-JP": {
+        "subtitleFont": "tom-thumb",
+        "subtitleHeight": 8,
+        "subtitleCascade": False,
+        "militaryPad": "",
+        "militaryNoun": [],
+        "militarySingularHours": [],
+        "ampm": [],
+        "dayPartFollowsHourWord": False,
+        "additiveHourIndex": 0,
+        "upperFixups": [],
+        "glyphs": True,
+        "lineHeight": 14,
     },
 }
 
@@ -1907,6 +2447,79 @@ def time_of_day(hour, timeOfDay, config, rules):
                 returnTime += timeRange["text"][rangeIndex]
         return returnTime
 
+# Chinese and Japanese have no font here to draw them with: every one of pixlet's
+# 27 built-in fonts is Latin, and each CJK codepoint renders as the same tofu box.
+# So those two dialects carry their own 12x12 bitmaps, one hex digit per three
+# pixels, twelve rows per glyph.
+#
+# Source: the Shinonome 12-dot gothic font (shnmk12), by Yasuyuki Furukawa and
+# maintained by /efont/ -- http://openlab.ring.gr.jp/efont/ -- released into the
+# public domain, with conversion and embedding explicitly permitted.
+#
+# JIS X 0208 has no simplified 两, so Chinese two o'clock uses the traditional 兩.
+# Same word, same reading; only the glyph is the older form.
+cjkGlyphs = {
+    "零": "7fc040ffe842b5a0a03f8c067f8048058040",
+    "一": "0000000000000007fe000000000000000000",
+    "二": "0000007fc000000000000000000ffe000000",
+    "三": "0007fc0000000003f8000000000000ffe000",
+    "四": "000ffe8a28a28a2926a1ec02802ffe000000",
+    "五": "0003fc0400400403f80480480880880887fe",
+    "六": "040040040ffe000120110208204404804000",
+    "七": "10010010010011efe01001001001041040fc",
+    "八": "0001f0010010110110110108208204404802",
+    "九": "0800800807f009009009009011011221240e",
+    "十": "040040040040ffe040040040040040040040",
+    "点": "04004007e0403f82082083f8000524492892",
+    "時": "020efca20a20bfee08bfea88a48a08e08018",
+    "分": "0900900881082045fa849048048088108230",
+    "半": "0402481481507fc040040ffe040040040040",
+    "刻": "102112ff2112292692152252482182242c06",
+    "差": "1100a07fc0403f8040ffe2003fc4208203fe",
+    "整": "220fbeaa4fa4758a942227fc04027c240ffe",
+    "兩": "000ffe040ffe842b5a94a94aad6c62842846",
+}
+
+CJK_SIZE = 12
+
+# the glyph box is inked edge to edge, so stacked lines need explicit leading
+CJK_LEAD = 2
+
+def cjk_row(bits, color):
+    children = []
+    run = 0
+    gap = 0
+    for i in range(CJK_SIZE):
+        if (bits >> (CJK_SIZE - 1 - i)) & 1:
+            if gap > 0:
+                children.append(render.Box(width = gap, height = 1))
+                gap = 0
+            run += 1
+        else:
+            if run > 0:
+                children.append(render.Box(width = run, height = 1, color = color))
+                run = 0
+            gap += 1
+    if run > 0:
+        children.append(render.Box(width = run, height = 1, color = color))
+    if gap > 0:
+        children.append(render.Box(width = gap, height = 1))
+    return render.Row(children = children)
+
+def cjk_char(ch, color):
+    hexrows = cjkGlyphs.get(ch)
+    if not hexrows:
+        return render.Box(width = CJK_SIZE, height = CJK_SIZE)
+    return render.Column(
+        children = [cjk_row(int(hexrows[i * 3:(i + 1) * 3], 16), color) for i in range(CJK_SIZE)],
+    )
+
+def cjk_line(text, color):
+    return render.Padding(
+        pad = (0, 0, 0, CJK_LEAD),
+        child = render.Row(children = [cjk_char(c, color) for c in text.codepoints()]),
+    )
+
 def to_caps(lines, rules):
     # .upper() leaves "ß" alone, so German would read "DREIßIG"; its uppercase is "SS"
     out = []
@@ -1916,9 +2529,8 @@ def to_caps(lines, rules):
         out.append(line.upper())
     return out
 
-def calculate_top_margin(showTime, subTime, littleH):
+def calculate_top_margin(showTime, subTime, bigH, littleH):
     fullHeight = 32
-    bigH = 8
 
     topMargin = int(math.ceil((fullHeight - (bigH * len(showTime)) - (littleH * len(subTime))) / 2))
 
@@ -1964,7 +2576,7 @@ def main(config):
         subTime = time_of_day(dayPartHour, timeOfDay, config, rules)
 
     # the panel is 32px tall; drop the subtitle rather than clip the time
-    if (8 * len(showTime)) + (rules["subtitleHeight"] * len(subTime)) > 32:
+    if (rules["lineHeight"] * len(showTime)) + (rules["subtitleHeight"] * len(subTime)) > 32:
         subTime = []
 
     # apply lettercase styling
@@ -1973,7 +2585,10 @@ def main(config):
         subTime = to_caps(subTime, rules)
 
     # render the words
-    textTime = [render.Text(" " * i + s) for i, s in enumerate(showTime)]
+    if rules["glyphs"]:
+        textTime = [cjk_line(s, "#fff") for s in showTime]
+    else:
+        textTime = [render.Text(" " * i + s) for i, s in enumerate(showTime)]
 
     subIndent = len(showTime) if rules["subtitleCascade"] else 0
 
@@ -1983,7 +2598,7 @@ def main(config):
     ) for i, s in enumerate(subTime)]
 
     # center the text vertically
-    topMargin = calculate_top_margin(showTime, subTime, rules["subtitleHeight"])
+    topMargin = calculate_top_margin(showTime, subTime, rules["lineHeight"], rules["subtitleHeight"])
 
     # once the column already fills the panel, a bottom pad costs it a row --
     # and that row is where the descenders of the last line live
@@ -2023,6 +2638,14 @@ def get_schema():
         schema.Option(
             display = "Português (Brasil)",
             value = "pt-BR",
+        ),
+        schema.Option(
+            display = "中文 (简体)",
+            value = "zh-CN",
+        ),
+        schema.Option(
+            display = "日本語",
+            value = "ja-JP",
         ),
     ]
 

--- a/apps/wordclock/word_clock.star
+++ b/apps/wordclock/word_clock.star
@@ -2606,7 +2606,7 @@ def is_square():
     """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
     2x square one 128x128, so a bare height test gets both wrong."""
     w, h = canvas.size()
-    return h * 2 > w + 16
+    return h == w
 
 def to_caps(lines, rules):
     # .upper() leaves "ß" alone, so German would read "DREIßIG"; its uppercase is "SS"


### PR DESCRIPTION
Follows #650, which added French. Adds **Deutsch (Deutschland)**, **Español (España)**,
**Italiano (Italia)**, **Português (Brasil)**, **中文 (简体)** and **日本語** — the last
two with their own embedded bitmap glyphs, since pixlet has no font that can draw them.

`en-US` is untouched — all 1440 minutes compared across 144 config combinations, byte
for byte.

| | |
|---|---|
| `HALB / NEUN / MORGENS` | de 08:30 |
| `ZEHN VOR / HALB ZWEI / NACHMITTAGS` | de 13:20 |
| `EINUND / ZWANZIG UHR / EINUND / ZWANZIG` | de 21:21, 24-hour |
| `LAS OCHO / Y CUARTO / DE LA MAÑANA` | es 08:15 |
| `LE NOVE / MENO / UN QUARTO` | it 08:45 |
| `QUINZE PARA / AS NOVE / DA MANHÃ` | pt 08:45 |

## Three fields, each forced by one language

Rather than let the tables grow hacks, `dialectObj` gained:

- **`additiveHourIndex`** — German says `ein Uhr` before the hour noun but `halb eins`
  in a relative phrase, so one hour slot cannot serve both. Every other dialect keeps
  index 0 and is unaffected.
- **`upperFixups`** — `.upper()` leaves `ß` alone, so German rendered `DREIßIG`, a
  lowercase glyph among capitals. Its uppercase is `SS`, and minutes 30–39 all carry one.
- **`militarySingularHours`** — French `zéro heure` is singular but Spanish `cero horas`
  is plural, so the hard-coded `hour <= 1` test had to become data.

An hour word may also now carry `|` as an authored line break, because
`zweiundzwanzig Uhr` is 69px on a 63px line. Words without one are unchanged, so it is
inert for the existing dialects.

## Language notes worth a reviewer's attention

- **German counts toward the coming hour.** `halb neun` is 08:30, not 09:30, and 13:20
  is `zehn vor halb zwei`. Every such form carries `h:1`. The regional `viertel neun` —
  08:15 in the east and south, 09:15 in the west — is deliberately **not** shipped: a
  word clock that is an hour wrong for a large minority is worse than one that is
  merely plainer. `Uhr` belongs to the hour word rather than the minute text, because
  giving it its own line made 21:21 five lines, which does not fit 32px.
- **`minuto` is MASCULINE in Spanish, Italian and Portuguese** — the opposite of French.
  None of them takes the French feminine: `las ocho y veintiuno`, `le otto e ventuno`,
  `oito e vinte e um`. This is the single easiest thing to get wrong when extending the
  French tables.
- **Italian numerals elide**: ventuno, ventotto, trentotto, quarantotto, cinquantotto,
  and ventitré with an acute. Line splits break on a syllable and never restore the
  deleted vowel — `quaran|totto`, not `quarant|otto`.
- **`mezzogiorno e mezzo` is masculine but `mezzanotte e mezza` is feminine**, so only
  noon needs a `specialObj` entry; midnight falls out of the ordinary tables.
- **Portuguese subtractive readings take a varying article** — `para as nove`,
  `para a uma`, `para o meio-dia` — which a minute entry cannot know, so those hours
  carry `specialObj` entries. `PARA AS QUATRO` is also 64px, so the count carries
  `para` and the article leads the hour line.
- **The daypart bands are not the English ones.** Spanish `de la tarde` runs to 21:00,
  four hours later than English "afternoon". German splits English "morning" into
  *morgens* and *vormittags* and has a one-hour *mittags* band. Mapping the English
  bands across would be wrong for hours a day in both.

All four use `tom-thumb` for the subtitle, as French does: `CG-pixel-3x5-mono` renders
every accented glyph zero-width, so `MAÑANA` would print as `MAANA`.

Game of Thrones is deliberately not translated — the hour names belong to an
English-language franchise and `game_of_thrones()` is already gated to `en-US`. The new
dialects carry a stub because `main()` indexes the table for whatever dialect is selected.


## Chinese and Japanese

These two could not be done the way the others were, because **pixlet has no font
that can draw them**. All 27 built-in fonts are Latin, `render.Text` only takes a
name from that fixed set, and every CJK codepoint comes back as the same tofu box —
八, 時, 一 and 十 render pixel-identically. Worth knowing for anyone who tries this
again: a tofu box has a normal advance width, so *measuring* a string is not enough
to tell you the glyph exists. You have to look at the pixels.

So these two dialects carry their own glyphs: **nineteen 12×12 bitmaps**, one hex
digit per three pixels, twelve rows each, **947 bytes in total**. They come from the
[Shinonome 12-dot gothic font](http://openlab.ring.gr.jp/efont/shinonome/) (shnmk12)
by Yasuyuki Furukawa, maintained by /efont/, which is **public domain** and whose
licence explicitly permits conversion and embedding (「自由な改造、他フォーマット
への変換、組込み、再配布を行うことができます」). `cjk_line()` walks a string's
codepoints and emits each glyph as run-length `Box`es — about 400 for a full panel,
which renders in the same ~10ms as the Latin path.

Nineteen glyphs covers both languages because the vocabulary is tiny: the digits,
点 and 時, 分, 半, 刻, 差 and 整. Every reading is the hour word on one line and the
minute word on the next, so nothing needs splitting and nothing exceeds four
glyphs — 48px of the 63 available.

| | |
|---|---|
| `八時 / 二十分` | ja 08:20 |
| `二十三時 / 五十九分` | ja 23:59, 24-hour |
| `兩点 / 五分` | zh 02:05 |
| `差一刻 / 九点` | zh 08:45 |
| `二十三点 / 五十九分` | zh 23:59, 24-hour |

Three judgement calls worth a reviewer's eye:

- **JIS X 0208 has no simplified 两**, so Chinese two o'clock uses the traditional
  **兩**. Same word, same reading (*liǎng*), older glyph. `二点` would have been the
  wrong *word*, which seemed worse than the right word in the wrong script. Anyone
  with a simplified bitmap to hand can drop it in. Chinese uses 兩 only at 2 and 14 —
  the compounds keep 二, so 22:00 is 二十二点 — and Japanese correctly takes 二時.
- **The glyph box is inked edge to edge**, so stacked lines carry 2px of leading.
  Without it 点 and 五 collide and the panel turns to mud.
- **Neither dialect gets a part-of-day complement.** At 12px a two-line time is 28px
  of the 32 available and a complement needs another 12, so it would show only at
  exact hours. An intermittent complement is worse than none, and 24-hour mode
  already disambiguates.

`dialectObj` gained `glyphs` and `lineHeight`; `calculate_top_margin` takes the line
height rather than assuming 8. The Latin dialects set `glyphs` to `False` and are
untouched.


## 64×64 panels

The app hardcoded a 32px panel in two places — `calculate_top_margin`'s `fullHeight`
and the subtitle-drop guard — so on a square panel everything sat in the top half and
the bottom 32 rows stayed black. Both now read `canvas.height()`, and square panels
get their own type sizes.

The thing that shapes this port: **a square panel is twice as tall but not one pixel
wider.** So bigger type does not simply fit — at `6x10`'s fixed 6px advance a line
holds ten characters against `tb-8`'s twelve, and ~200 of the lines the tables can
emit no longer do. Rather than fork every dialect table, `wrap_lines()` rebreaks them
at render time: the last space or hyphen inside the budget, three passes, applied
before the lettercase styling so it can key on the authored case.

Exactly **nine words** have no space or hyphen to break on — *Mitternacht*,
*nachmittags*, *mezzogiorno*, *diciassette*, *quattordici*, *veinticinco*,
*veintisiete*, *veintinueve* and en-US's *nightengale*, all eleven characters — and
each gets an explicit compound or syllable split. That list was derived by
enumerating all **1132 distinct lines** the tables produce, not by eye.

Chinese and Japanese move to the **16-dot cut of the same Shinonome font**. Four
glyphs still fit a line, and 16px is where these characters become comfortably
legible rather than merely resolvable. Square CJK gives up the 1px left margin,
because four 16px glyphs fill the panel exactly and the rightmost column of the glyph
box is inked.

Also on square: no staircase indent, on the text or the subtitle — at 6px a space
costs more of the line than the extra height buys back.

Shape is detected with `canvas.size()` rather than a height test, matching the
convention in the other 64×64 app ports: a 2x wide panel reports 128×64 and a 2x
square one 128×128, so a bare height comparison gets both wrong. (Note the `canvas`
module loads from `render.star`, not `canvas.star` as AGENTS.md implies.)

## Verification

On the pinned pixlet **v0.50.1**, at **both panel shapes**, per dialect: **1440
minutes × 144 config combinations** — every military × display × caps × time-of-day ×
Game-of-Thrones combination, sweeping the random picker across all its branches.
**3,317,760 time × config combinations across the eight dialects on 64×32 and 64×64.**
Every rendered line was width-checked against a per-character advance table measured
from the actual fonts.

- 0 render aborts
- 0 lines wider than the panel (widest is 64px of 64)
- 0 stacks taller than 32px
- 0 missing glyphs
- 64×32 output is unchanged: 448 en-US frames compared as rendered images, byte for
  byte, differ only where the noon/midnight crash used to be
- `pixlet format` / `lint` / `check` clean; renders in ~10ms at both shapes against
  CI's 1s budget

The default is unchanged, so no existing installation moves; `dialectOptions[0]` is
still `en-US` and the new options are appended after it.
