### PR TITLE
footballtable: add a 64x64 layout

### DIFF
--- a/apps/footballtable/footballtable.star
+++ b/apps/footballtable/footballtable.star
@@ -20,7 +20,7 @@ def is_square():
     """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
     2x square one 128x128, so a bare height test gets both wrong."""
     w, h = canvas.size()
-    return h * 2 > w + 16
+    return h == w
 
 def main(config):
     relCount = 0

--- a/apps/footballtable/footballtable.star
+++ b/apps/footballtable/footballtable.star
@@ -6,7 +6,7 @@ Author: plumbob86
 """
 
 load("http.star", "http")
-load("render.star", "render")
+load("render.star", "canvas", "render")
 load("schema.star", "schema")
 
 leagueCode = "ELC"
@@ -15,6 +15,12 @@ RED = "#FFFFFF"
 WHITE = "#FF0000"
 GREEN = "#00FF00"
 PLAYOFF = "#008000"
+
+def is_square():
+    """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
+    2x square one 128x128, so a bare height test gets both wrong."""
+    w, h = canvas.size()
+    return h * 2 > w + 16
 
 def main(config):
     relCount = 0
@@ -67,6 +73,10 @@ def main(config):
     else:
         print("Miss! Calling API.")
 
+    # square panels fit eight 8px rows per page instead of four
+    if is_square():
+        return renderSquareTable(table, clubCount, relCount, playCount, proCount)
+
     stackList = []
     usehue = "#FFFFFF"
 
@@ -100,6 +110,43 @@ def main(config):
 
     return render.Root(
         delay = int(15000 / (clubCount / 4)),
+        child =
+            render.Animation(
+                children = (
+                    stackList
+                ),
+            ),
+    )
+
+def renderSquareTable(table, clubCount, relCount, playCount, proCount):
+    stackList = []
+    usehue = "#FFFFFF"
+
+    for i in range(0, len(table), 8):
+        textList = []
+
+        padNum = 0
+        for j in range(8):
+            if j + i < len(table):
+                if i + j < proCount:
+                    usehue = GREEN
+                elif i + j > (clubCount - 1) - relCount:
+                    usehue = WHITE
+                elif (i + j >= proCount) and (i + j < proCount + playCount):
+                    usehue = PLAYOFF
+                else:
+                    usehue = RED
+                position = ""
+                if (i + j + 1) < 10:
+                    position = "0" + str(i + j + 1)
+                else:
+                    position = str(i + j + 1)
+                textList.append(render.Padding(pad = (0, padNum, 0, 0), child = render.Text(color = usehue, content = "#" + position + " " + table[i + j].get("team").get("tla") + " Pts:" + str(int(table[i + j].get("points"))))))
+                padNum += 8
+        stackList.append(render.Stack(children = textList))
+
+    return render.Root(
+        delay = int(15000 / (clubCount / 8)),
         child =
             render.Animation(
                 children = (

--- a/apps/footballtable/manifest.yaml
+++ b/apps/footballtable/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - nfl
   - football
 published: '2023-11-09T15:23:28Z'
-updated: '2026-09-02T07:05:31Z'
+updated: '2026-09-03T04:50:12Z'

--- a/apps/footballtable/manifest.yaml
+++ b/apps/footballtable/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - nfl
   - football
 published: '2023-11-09T15:23:28Z'
-updated: '2025-12-02T19:30:22Z'
+updated: '2026-09-02T07:05:31Z'


### PR DESCRIPTION
Square (64x64) panels render this app's 2:1 layout top-anchored with the bottom half black. This adds a square layout, gated on `canvas.size()` shape, so 64x64 devices get a display designed for the panel; the 64x32 and 128x64 output is untouched — byte-identical, verified per config below.

## What the square layout shows

The wide layout pages through the league table four 8px tb-8 rows at a time; on a 64x64 panel that left the bottom half of the screen black. The square branch keeps the exact same row format ("#NN TLA Pts:P"), font, and promotion/playoff/relegation hue logic, but paginates eight rows per frame — 8 rows x 8px fills the 64px height exactly, so a 20-club league needs 3 pages instead of 5 and each frame shows twice the table. The page delay mirrors the wide formula with 4 swapped for 8 (int(15000 / (clubCount / 8))), preserving the app's ~15s full-cycle cadence. The remainder page (e.g. positions 17-20 for a 20-club league) is shorter, which is the app's existing convention — the wide layout produces the same partial final page (BL1 wide ends on a 2-row frame). Implementation is purely additive: a shape predicate, an early-return branch in main after the existing fetch (no second HTTP call), and one helper that duplicates the wide row-building loop with an 8-row stride.

## Verification

- 2 configs x {64x32, 128x64}, A/B/A byte-identical: for all 4 triples sha256(A1) == sha256(A2) == sha256(B). Pristine renders came from `git show HEAD` copies of the app.
- Configs exercised:
  - (default) league=PL — 20 clubs: 3 square pages of 8/8/4 rows; mid-table white and relegation red hues exercised
  - league=BL1 — 18 clubs: square pages 8/8/2; relegation hue starting mid-page (#16 red on page 2) and the short remainder page exercised
- `pixlet check` passes on pixlet v0.50.1 (the CI pin); cold 64x64 render ~0.54s against the 1s budget.

## Notes for review

- ELC (the only league with proCount/playCount > 0, i.e. GREEN promotion and PLAYOFF hues) was not rendered — the task intel capped the config sample at default + BL1 because of football-data.org's ~10 req/min free-tier limit. The hue conditionals in the square helper are copied verbatim from the wide loop, and BL1 verified the relegation branch fires mid-page.
- The square delay formula intentionally mirrors the wide one (15000 / (clubCount / 8)); where clubCount is not a multiple of 8 the total cycle overshoots 15s slightly (PL: 3 x 6000ms = 18s), exactly analogous to the wide layout's own rounding (BL1 wide: 5 x 3333ms ~= 16.7s). Same float-division-inside-int() style as the original.
- The last square page can be short (BL1: 2 rows) — kept deliberately, matching the wide layout's identical remainder-page behavior rather than redistributing rows, which would leave dead space on every page.
- The original file's RED/WHITE constants are name-swapped (RED = #FFFFFF, WHITE = #FF0000); the square branch uses them the same way the wide code does, and they were left untouched per the byte-identity contract.
- It is early season (matchday ~2-3), so rendered points values are single digits; row text is ~14 chars of tb-8 which already runs to the panel edge on wide, and the square branch inherits that width behavior unchanged.
- Renders were spaced 8s apart; no rate-limit failures were observed during verification. Data was stable across every A/B/A triple (A1 == A2 on the first pass, no reruns needed).
- pixlet check passed (runs default config, wide sizes, 1s budget); the square branch adds no HTTP request, so the cold 64x64 render is the same single API call (0.54s real).
