### PR TITLE
eplscores: add a 64x64 layout

### DIFF
--- a/apps/eplscores/eplscores.star
+++ b/apps/eplscores/eplscores.star
@@ -959,7 +959,7 @@ def is_square():
     """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
     2x square one 128x128, so a bare height test gets both wrong."""
     w, h = canvas.size()
-    return h * 2 > w + 16
+    return h == w
 
 def get_square_root(games, displayType, displayTop, now, rotationSpeed, timeColor):
     if displayType == "retro":

--- a/apps/eplscores/eplscores.star
+++ b/apps/eplscores/eplscores.star
@@ -7,7 +7,7 @@ Author: mabroadfo1027
 
 load("encoding/json.star", "json")
 load("http.star", "http")
-load("render.star", "render")
+load("render.star", "canvas", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
@@ -78,6 +78,7 @@ MAGNIFY_LOGO = """
 
 def main(config):
     renderCategory = []
+    gameData = []
     selectedTeam = config.get("selectedTeam", "all")
     displayType = config.get("displayType", "colors")
     pregameDisplay = config.get("pregameDisplay", "record")
@@ -221,6 +222,25 @@ def main(config):
                     else:
                         homeScoreColor = "#fff"
                         awayScoreColor = "#fff"
+
+            gameData.append({
+                "home": home,
+                "away": away,
+                "homeTeamName": homeTeamName,
+                "awayTeamName": awayTeamName,
+                "homeColor": homeColor,
+                "awayColor": awayColor,
+                "homeLogo": homeLogo,
+                "awayLogo": awayLogo,
+                "homeLogoSize": homeLogoSize,
+                "awayLogoSize": awayLogoSize,
+                "homeScore": homeScore,
+                "awayScore": awayScore,
+                "homeScoreColor": homeScoreColor,
+                "awayScoreColor": awayScoreColor,
+                "gameTime": gameTime,
+                "scoreFont": scoreFont,
+            })
 
             if displayType == "retro":
                 retroTextColor = "#ffe065"
@@ -487,6 +507,9 @@ def main(config):
                         ),
                     ],
                 )
+
+        if is_square():
+            return get_square_root(gameData, displayType, displayTop, now, rotationSpeed, timeColor)
 
         return render.Root(
             delay = int(rotationSpeed) * 1000,
@@ -931,3 +954,185 @@ def get_cachable_data(url, ttl_seconds = CACHE_TTL_SECONDS):
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
 
     return res.body()
+
+def is_square():
+    """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
+    2x square one 128x128, so a bare height test gets both wrong."""
+    w, h = canvas.size()
+    return h * 2 > w + 16
+
+def get_square_root(games, displayType, displayTop, now, rotationSpeed, timeColor):
+    if displayType == "retro":
+        textColor = "#ffe065"
+        borderColor = "#000"
+    elif displayType == "stadium":
+        textColor = "#fff"
+        borderColor = "#345252"
+    else:
+        textColor = "#fff"
+        borderColor = "#000"
+    squareScreens = []
+    for j in range(0, len(games), 2):
+        topGame = games[j]
+        frameChildren = [
+            render.Row(
+                expanded = True,
+                main_align = "space_between",
+                cross_align = "start",
+                children = get_date_column(displayTop, now, j // 2, rotationSpeed, textColor, borderColor, displayType, topGame["gameTime"], timeColor),
+            ),
+        ]
+        if j + 1 < len(games):
+            bottomGame = games[j + 1]
+            frameChildren.append(get_square_card(topGame, displayType))
+            frameChildren.extend(get_date_column("gameinfo", now, j // 2, rotationSpeed, textColor, borderColor, displayType, bottomGame["gameTime"], timeColor))
+            frameChildren.append(get_square_card(bottomGame, displayType))
+        else:
+            frameChildren.extend(get_square_detail(topGame, displayType, textColor))
+        squareScreens.append(render.Column(children = frameChildren))
+    return render.Root(
+        delay = int(rotationSpeed) * 1000,
+        show_full_animation = True,
+        child = render.Column(
+            children = [
+                render.Animation(
+                    children = squareScreens,
+                ),
+            ],
+        ),
+    )
+
+def get_square_card(game, displayType):
+    scoreFont = game["scoreFont"]
+    if displayType == "retro":
+        retroTextColor = "#ffe065"
+        retroFont = "CG-pixel-3x5-mono"
+        return render.Column(
+            children = [
+                render.Box(width = 64, height = 12, color = game["homeColor"], child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                    render.Box(width = 40, height = 12, child = render.Text(content = get_team_name(game["homeTeamName"]), color = retroTextColor, font = retroFont)),
+                    render.Box(width = 26, height = 12, child = render.Text(content = get_record(game["homeScore"]), color = retroTextColor, font = retroFont)),
+                ])),
+                render.Box(width = 64, height = 12, color = game["awayColor"], child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                    render.Box(width = 40, height = 12, child = render.Text(content = get_team_name(game["awayTeamName"]), color = retroTextColor, font = retroFont)),
+                    render.Box(width = 26, height = 12, child = render.Text(content = get_record(game["awayScore"]), color = retroTextColor, font = retroFont)),
+                ])),
+            ],
+        )
+    elif displayType == "stadium":
+        backgroundColor = "#0f3027"
+        borderColor = "#345252"
+        textFont = "tb-8"
+        return render.Column(
+            children = [
+                render.Box(width = 64, height = 12, color = borderColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                    render.Box(width = 1, height = 10, color = borderColor),
+                    render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = game["home"][:3].upper(), color = game["homeScoreColor"], font = textFont))),
+                    render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = get_record(game["homeScore"]), color = game["homeScoreColor"], font = scoreFont))),
+                    render.Box(width = 1, height = 10, color = borderColor),
+                ])),
+                render.Box(width = 64, height = 1, color = borderColor),
+                render.Box(width = 64, height = 10, color = borderColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                    render.Box(width = 1, height = 10, color = borderColor),
+                    render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = game["away"][:3].upper(), color = game["awayScoreColor"], font = textFont))),
+                    render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = get_record(game["awayScore"]), color = game["awayScoreColor"], font = scoreFont))),
+                    render.Box(width = 1, height = 10, color = borderColor),
+                ])),
+                render.Box(width = 64, height = 1, color = borderColor),
+            ],
+        )
+    elif displayType == "horizontal":
+        return render.Row(
+            children = [
+                render.Box(width = 32, height = 24, color = game["homeColor"], child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                    render.Column(expanded = True, main_align = "start", cross_align = "center", children = [
+                        render.Stack(children = [
+                            render.Box(width = 32, height = 24, child = render.Image(game["homeLogo"], width = 32, height = 32)),
+                            render.Column(expanded = True, main_align = "start", cross_align = "center", children = [
+                                render.Box(width = 32, height = 16),
+                                render.Box(width = 32, height = 8, color = "#000a", child = render.Text(content = game["homeScore"], color = game["homeScoreColor"], font = scoreFont)),
+                            ]),
+                        ]),
+                    ]),
+                ])),
+                render.Box(width = 32, height = 24, color = game["awayColor"], child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                    render.Column(expanded = True, main_align = "start", cross_align = "center", children = [
+                        render.Stack(children = [
+                            render.Box(width = 32, height = 24, child = render.Image(game["awayLogo"], width = 32, height = 32)),
+                            render.Column(expanded = True, main_align = "start", cross_align = "center", children = [
+                                render.Box(width = 32, height = 16),
+                                render.Box(width = 32, height = 8, color = "#000a", child = render.Text(content = game["awayScore"], color = game["awayScoreColor"], font = scoreFont)),
+                            ]),
+                        ]),
+                    ]),
+                ])),
+            ],
+        )
+    elif displayType == "logos":
+        return render.Column(
+            children = [
+                render.Box(width = 64, height = 12, color = game["homeColor"], child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                    render.Image(game["homeLogo"], width = 30, height = 30),
+                    render.Box(width = 34, height = 12, child = render.Text(content = game["homeScore"], color = game["homeScoreColor"], font = scoreFont)),
+                ])),
+                render.Box(width = 64, height = 12, color = game["awayColor"], child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                    render.Image(game["awayLogo"], width = 30, height = 30),
+                    render.Box(width = 34, height = 12, child = render.Text(content = game["awayScore"], color = game["awayScoreColor"], font = scoreFont)),
+                ])),
+            ],
+        )
+    else:
+        textFont = "Dina_r400-6"
+        return render.Column(
+            children = [
+                render.Box(width = 64, height = 12, color = game["homeColor"], child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                    render.Box(width = 16, height = 16, child = render.Image(game["homeLogo"], width = game["homeLogoSize"], height = game["homeLogoSize"])),
+                    render.Box(width = 24, height = 12, child = render.Text(content = game["home"][:3], color = game["homeScoreColor"], font = textFont)),
+                    render.Box(width = 24, height = 12, child = render.Text(content = get_record(game["homeScore"]), color = game["homeScoreColor"], font = scoreFont)),
+                ])),
+                render.Box(width = 64, height = 12, color = game["awayColor"], child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                    render.Box(width = 16, height = 16, child = render.Image(game["awayLogo"], width = game["awayLogoSize"], height = game["awayLogoSize"])),
+                    render.Box(width = 24, height = 12, child = render.Text(content = game["away"][:3], color = game["awayScoreColor"], font = textFont)),
+                    render.Box(width = 24, height = 12, child = render.Text(content = get_record(game["awayScore"]), color = game["awayScoreColor"], font = scoreFont)),
+                ])),
+            ],
+        )
+
+def get_square_detail(game, displayType, textColor):
+    detailFont = "CG-pixel-3x5-mono"
+    if displayType == "retro":
+        return [
+            render.Box(width = 64, height = 27, color = "#222", child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                render.Box(width = 38, height = 27, child = render.Text(content = get_team_name(game["homeTeamName"]), color = textColor, font = detailFont)),
+                render.Box(width = 26, height = 27, child = render.Text(content = get_record(game["homeScore"]), color = textColor, font = detailFont)),
+            ])),
+            render.Box(width = 64, height = 2),
+            render.Box(width = 64, height = 27, color = "#222", child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                render.Box(width = 38, height = 27, child = render.Text(content = get_team_name(game["awayTeamName"]), color = textColor, font = detailFont)),
+                render.Box(width = 26, height = 27, child = render.Text(content = get_record(game["awayScore"]), color = textColor, font = detailFont)),
+            ])),
+        ]
+    elif displayType == "stadium":
+        return [
+            get_square_card(game, displayType),
+            render.Box(width = 64, height = 4),
+            render.Box(width = 64, height = 14, color = "#345252", child = render.Box(width = 62, height = 12, color = "#0f3027", child = render.Row(expanded = True, main_align = "center", cross_align = "center", children = [
+                render.Text(content = get_team_name(game["homeTeamName"]), color = game["homeScoreColor"], font = "tb-8"),
+            ]))),
+            render.Box(width = 64, height = 14, color = "#345252", child = render.Box(width = 62, height = 12, color = "#0f3027", child = render.Row(expanded = True, main_align = "center", cross_align = "center", children = [
+                render.Text(content = get_team_name(game["awayTeamName"]), color = game["awayScoreColor"], font = "tb-8"),
+            ]))),
+        ]
+    else:
+        homeRowColor = displayType == "black" and "#222" or game["homeColor"]
+        awayRowColor = displayType == "black" and "#222" or game["awayColor"]
+        return [
+            get_square_card(game, displayType),
+            render.Box(width = 64, height = 4),
+            render.Box(width = 64, height = 14, color = homeRowColor, child = render.Row(expanded = True, main_align = "center", cross_align = "center", children = [
+                render.Text(content = get_team_name(game["homeTeamName"]), color = game["homeScoreColor"], font = "tb-8"),
+            ])),
+            render.Box(width = 64, height = 14, color = awayRowColor, child = render.Row(expanded = True, main_align = "center", cross_align = "center", children = [
+                render.Text(content = get_team_name(game["awayTeamName"]), color = game["awayScoreColor"], font = "tb-8"),
+            ])),
+        ]

--- a/apps/eplscores/manifest.yaml
+++ b/apps/eplscores/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - real-time
   - soccer
 published: '2022-09-15T19:39:29Z'
-updated: '2026-09-02T07:05:43Z'
+updated: '2026-09-03T04:50:12Z'

--- a/apps/eplscores/manifest.yaml
+++ b/apps/eplscores/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - real-time
   - soccer
 published: '2022-09-15T19:39:29Z'
-updated: '2025-12-02T19:30:22Z'
+updated: '2026-09-02T07:05:43Z'


### PR DESCRIPTION
Square (64x64) panels render this app's 2:1 layout top-anchored with the bottom half black. This adds a square layout, gated on `canvas.size()` shape, so 64x64 devices get a display designed for the panel; the 64x32 and 128x64 output is untouched — byte-identical, verified per config below.

## What the square layout shows

On 64x64 the app now shows two matches per frame instead of one: the existing 8px top shelf (league/time plus the first game's status) sits above the first 24px match card, then a centered 8px status band — the app's own "gameinfo" shelf — labels and divides the second card, filling all 64 rows (8+24+8+24). Cards are pixel-identical rebuilds of each of the six display types' wide cards, so winner-yellow scores, team-color rows, stadium borders and retro styling all carry over unchanged. Frame count halves (ceil(N/2)) while per-frame delay stays rotationSpeed seconds, matching the wide app's cadence conventions. An odd tail game — or a single-fixture day, common in the EPL feed — gets a richer lone frame: the normal card plus full club-name banners (tb-8, winner-colored) that the 3-letter wide cards never had room for; retro instead stretches its name+record rows to fill, since its card already shows full names. The wide 64x32/128x64 output is untouched to the byte; the previous 64x64 behavior (header pinned top, card pinned bottom, ~32 dead rows between from the space_between column) is replaced only in the new is_square() branch.

## Verification

- 6 configs x {64x32, 128x64} = 12 A/B/A triples, all byte-identical (sha256(A1)==sha256(A2)==sha256(B) for every triple; no unstable reruns needed). Pristine renders came from `git show HEAD` copies of the app.
- Configs exercised:
  - (default: colors, league, record, 5s) — pre-game state, single live fixture, lone square frame
  - displayType=retro displayTop=time — projected clock on top shelf, retro lone frame
  - displayType=stadium pregameDisplay=nothing — bordered scoreboard cells, empty score slots
  - displayType=horizontal rotationSpeed=3 — big-crest cards, 3s delay verified in webp frame timings
  - displayType=black selectedTeam=ARS displayTop=gameinfo — team-focus fetch path (dated query), centered status shelf
  - displayType=logos pregameDisplay=form — crest+score rows, form strings in score slots
- `pixlet check` passes on pixlet v0.50.1 (the CI pin); cold 64x64 render ~0.1s against the 1s budget.

## Notes for review

- pregameDisplay=odds aborts the render in the PRISTINE app with current live data (eplscores.star:154 competition["odds"][1] — ESPN now returns a single odds provider, so index 1 is out of range). Pre-existing bug, not introduced or touched by this port; that config could not be baselined or A/B/A'd.
- Live feed had exactly one event (IPS v LIV, pre) during the port — an EPL single-fixture day — so pair frames could not be exercised through the shipped file.
- The in-progress ('in') state was synthesized in the mock payload (one pre event flipped to state=in, 63', 1-2) — no EPL match was live during the work; pre and post states are untouched real data.
- The square cards deliberately inherit the wide cards' existing quirks (logo overflow past the 12px rows in colors/black, 32x32 crests cropped into 24px boxes in horizontal) — that is the app's current visual language, reproduced exactly.
- displayTop=time advances the projected clock by frame index (j//2) x rotationSpeed on square, mirroring the wide convention of per-displayed-frame offsets.
- The no-games state (empty feed) returns [] on square exactly as wide does — exercised implicitly early on (selectedTeam=ARS before ARS v CHE entered the date window) but not kept as a baselined config since the state vanished as ESPN data moved.
- get_square_detail's black-type row-color conditional is redundant (homeColor is already #222 for black) but kept to mirror the wide black branch's explicit hardcoding.
- 0.1s square render reflects today's tiny feed (1 event, 2 crests); the mock 20-event square render was also sub-second, and pixlet check (1s CI budget, cold cache, default config) passes.
