### PR TITLE
soccertables: add a 64x64 layout

### DIFF
--- a/apps/soccertables/manifest.yaml
+++ b/apps/soccertables/manifest.yaml
@@ -11,4 +11,4 @@ category: sports
 tags:
   - soccer
 published: '2023-01-12T16:57:44Z'
-updated: '2026-08-24T22:26:35Z'
+updated: '2026-09-02T07:05:47Z'

--- a/apps/soccertables/manifest.yaml
+++ b/apps/soccertables/manifest.yaml
@@ -11,4 +11,4 @@ category: sports
 tags:
   - soccer
 published: '2023-01-12T16:57:44Z'
-updated: '2026-09-02T07:05:47Z'
+updated: '2026-09-03T04:50:17Z'

--- a/apps/soccertables/soccer_tables.star
+++ b/apps/soccertables/soccer_tables.star
@@ -101,7 +101,7 @@ def is_square():
     """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
     2x square one 128x128, so a bare height test gets both wrong."""
     w, h = canvas.size()
-    return h * 2 > w + 16
+    return h == w
 
 def main_square(config):
     # 64x64 version of the same table - the 8px league header stays, and the extra height fits 8 team rows of 7px per page instead of 4

--- a/apps/soccertables/soccer_tables.star
+++ b/apps/soccertables/soccer_tables.star
@@ -24,7 +24,7 @@ Added Champions League, Europa League and Europa Conference League
 
 load("encoding/json.star", "json")
 load("http.star", "http")
-load("render.star", "render")
+load("render.star", "canvas", "render")
 load("schema.star", "schema")
 
 CACHE_TTL_SECONDS = 300
@@ -40,6 +40,9 @@ ALT_COLOR = """
 """
 
 def main(config):
+    if is_square():
+        return main_square(config)
+
     renderCategory = []
     teamsToShow = 4
 
@@ -81,6 +84,66 @@ def main(config):
                                 children = [
                                     render.Column(
                                         children = get_team(x, entries, entriesToDisplay, 25, LeagueName, 8, selectedColor, selectedDisplay),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    )
+        return render.Root(
+            show_full_animation = True,
+            delay = int(RotationSpeed) * 1000,
+            child = render.Animation(children = renderCategory),
+        )
+    else:
+        return []
+
+def is_square():
+    """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
+    2x square one 128x128, so a bare height test gets both wrong."""
+    w, h = canvas.size()
+    return h * 2 > w + 16
+
+def main_square(config):
+    # 64x64 version of the same table - the 8px league header stays, and the extra height fits 8 team rows of 7px per page instead of 4
+    renderCategory = []
+    teamsToShow = 8
+
+    RotationSpeed = config.get("speed", "3")
+    selectedLeague = config.get("LeagueOptions", DEFAULT_LEAGUE)
+    selectedColor = config.get("ColorOptions", "black")
+    selectedDisplay = config.get("DisplayOptions", "Rank")
+    league2 = {API: API + selectedLeague + "/standings"}
+
+    standings = get_standings(league2)
+    statNumber = 0
+
+    if (standings):
+        for _, s in enumerate(standings[0]["children"]):
+            entries = s["standings"]["entries"]
+
+            if entries:
+                entriesToDisplay = teamsToShow
+                LeagueName = getLeagueName(selectedLeague)
+                if selectedLeague == "usa.1":
+                    LeagueName = LeagueName + " - " + s["abbreviation"]
+                stats = entries[0]["stats"]
+
+                for j, k in enumerate(stats):
+                    if k["name"] == "rank":
+                        statNumber = j
+
+                entries = sorted(entries, key = lambda e: e["stats"][statNumber]["value"], reverse = False)
+
+                for x in range(0, len(entries), entriesToDisplay):
+                    renderCategory.extend(
+                        [
+                            render.Column(
+                                expanded = True,
+                                main_align = "start",
+                                cross_align = "start",
+                                children = [
+                                    render.Column(
+                                        children = get_team(x, entries, entriesToDisplay, 56, LeagueName, 8, selectedColor, selectedDisplay),
                                     ),
                                 ],
                             ),


### PR DESCRIPTION
Square (64x64) panels render this app's 2:1 layout top-anchored with the bottom half black. This adds a square layout, gated on `canvas.size()` shape, so 64x64 devices get a display designed for the panel; the 64x32 and 128x64 output is untouched — byte-identical, verified per config below.

## What the square layout shows

On 64x64 the app keeps its exact visual language — the 8px yellow league-name header, CG-pixel-3x5-mono rows, qualification/relegation rank colors, and the same column widths — but shows 8 team rows per animation page instead of 4 (8px header + 8 rows x 7px = 64, exact). Implementation is a purely additive main_square() that reuses the existing get_team() renderer with colHeight=56/entriesToDisplay=8, so both DisplayOptions modes (Rank+Pts+GD and W-D-L), both ColorOptions (rank colors and team-color row backgrounds), the MLS per-conference headers, and the rotation-speed delay all work unchanged; only the shape predicate and one load-line symbol touch existing code. A full EPL table now fits in 3 pages instead of 5 (Champions League: 5 instead of 9), with per-page delay conventions identical to wide. The last partial page keeps the app's existing filler-row (#111) convention, same as wide layouts for 18-team leagues.

## Verification

- 6 configs x {64x32, 128x64} = 12 A/B/A triples, all byte-identical (sha256(A1)==sha256(A2)==sha256(B) in every triple; no unstable triples, no reruns needed). Also verified pixlet format + lint leave the modified file byte-identical (sha256 unchanged), and the diff preserves the original file's CRLF bytes inside the docstring/ALT_COLOR literals (64 insertions, 1 deletion: the load line). Pristine renders came from `git show HEAD` copies of the app.
- Configs exercised:
  - (default: eng.1, Rank, black, speed 3) — EPL 20 teams, rank colors green/blue/red, 3 square pages
  - LeagueOptions=ger.1 — Bundesliga 18 teams, 2-team last page with 6 filler rows
  - LeagueOptions=uefa.champions — 36-entry UEFA league phase, 2-digit ranks 17-36, yellow/red tiers, 5 square pages, pre-season 0-0 state
  - DisplayOptions=WDL — W-D-L record layout at 8 rows
  - ColorOptions=color — per-team background-color path (extra per-team HTTP fetches), full-height 7px colored rows
  - LeagueOptions=usa.1 speed=5 — MLS conference children ('MLS - EAST'/'MLS - WEST' headers), 15-team conferences paged 8+7, 5s delay
- `pixlet check` passes on pixlet v0.50.1 (the CI pin); cold 64x64 render ~0.11s against the 1s budget.

## Notes for review

- Renders are unusually fast (~0.06-0.11s cold) because ESPN standings are CDN-served; I verified real data is fetched (never-before-hit leagues esp.1/por.1 rendered live tables), so pixlet check's 1s budget is comfortably met and the square branch adds zero extra HTTP requests.
- Last animation page keeps the app's existing partial-page convention: missing rows render as #111 filler boxes (wide does the same for 18-team leagues). On square a 20-team league's last page has 4 filler rows — visible as a dark lower band on that one page only.
- 128x128 (2x square) takes the square branch but get_team() hardcodes 64px widths exactly as the wide branch does; per the guide that size is unreachable from real servers and was not special-cased.
- The dead cycleCount variable in the wide main() was deliberately not duplicated into main_square().
- Could not exercise the empty-standings/entries-empty paths (API always returned data); square inherits the wide branch's exact fallbacks (return []).
- Season state at test time: EPL/Bundesliga/La Liga at matchday 2-3, UCL league phase not started (all 0-0) — that pre-season 0-0 state was exercised via uefa.champions.
- The original file contains CRLF line endings inside its docstring and ALT_COLOR string literals; the Edit tool normalizes these, so edits were applied via a byte-level python script to keep untouched lines byte-identical. pixlet format/lint accept the file as-is.
- Nothing committed or pushed.
