### PR TITLE
mlbdivstandings: add a 64x64 layout

### DIFF
--- a/apps/mlbdivstandings/manifest.yaml
+++ b/apps/mlbdivstandings/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - mlb
   - baseball
 published: '2023-09-06T13:53:38Z'
-updated: '2026-09-02T07:05:53Z'
+updated: '2026-09-03T04:50:13Z'

--- a/apps/mlbdivstandings/manifest.yaml
+++ b/apps/mlbdivstandings/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - mlb
   - baseball
 published: '2023-09-06T13:53:38Z'
-updated: '2025-12-02T19:30:22Z'
+updated: '2026-09-02T07:05:53Z'

--- a/apps/mlbdivstandings/mlbdivstandings.star
+++ b/apps/mlbdivstandings/mlbdivstandings.star
@@ -156,7 +156,7 @@ def is_square():
     """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
     2x square one 128x128, so a bare height test gets both wrong."""
     w, h = canvas.size()
-    return h * 2 > w + 16
+    return h == w
 
 def get_schema():
     options = [

--- a/apps/mlbdivstandings/mlbdivstandings.star
+++ b/apps/mlbdivstandings/mlbdivstandings.star
@@ -40,7 +40,7 @@ load("images/tb_logo.png", TB_LOGO_ASSET = "file")
 load("images/tex_logo.png", TEX_LOGO_ASSET = "file")
 load("images/tor_logo.png", TOR_LOGO_ASSET = "file")
 load("images/was_logo.png", WAS_LOGO_ASSET = "file")
-load("render.star", "render")
+load("render.star", "canvas", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
@@ -92,6 +92,11 @@ def main(config):
     year = str(time.now().year)  # use current year
 
     standings = get_Standings(division_id, year)
+
+    # square panels get a second tier: the same card carousel up top
+    # plus the whole division table underneath
+    if is_square():
+        return render_square(standings, division_id, year)
 
     # if we have some widgets, we can display them now
     if len(standings) > 0:
@@ -146,6 +151,12 @@ def build_keyframe(offset, pct):
         transforms = [animation.Translate(offset, 0)],
         curve = "ease_in_out",
     )
+
+def is_square():
+    """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
+    2x square one 128x128, so a bare height test gets both wrong."""
+    w, h = canvas.size()
+    return h * 2 > w + 16
 
 def get_schema():
     options = [
@@ -375,6 +386,134 @@ def render_record_info(team, clinched, wins, losses, games_back, div_rank):
             render_rainbow_word("DIV", SMALL_FONT),
             render_rainbow_word("CHAMP", SMALL_FONT),
         ]
+
+def render_square(standings, division_id, year):
+    # zero-state, square edition: marquee below the league image
+    # instead of on top of it
+    if len(standings) == 0:
+        return render.Root(
+            child = render.Column(
+                children = [
+                    render.Image(
+                        src = MLB_LEAGUE_IMAGE,
+                    ),
+                    render.Box(
+                        height = 32,
+                        width = 64,
+                        child = render.Marquee(
+                            width = 64,
+                            child = render.Text(
+                                content = "No standings to display for league year " + year,
+                                color = SMALL_FONT_COLOR,
+                                font = SMALL_FONT,
+                            ),
+                        ),
+                    ),
+                ],
+            ),
+        )
+
+    # breathing room between the carousel and the table
+    table_rows = [render.Box(height = 1, width = 64)]
+    for info in standings:
+        table_rows.append(render_table_row(info))
+
+    return render.Root(
+        delay = 80,
+        show_full_animation = True,
+        child = render.Column(
+            children = [
+                render.Row(
+                    children = [
+                        render_lefter(division_id),
+                        animation.Transformation(
+                            duration = 180,
+                            width = 295,
+                            height = 32,
+                            keyframes = [
+                                build_keyframe(0, 0.0),
+                                build_keyframe(0, 0.08),
+                                build_keyframe(-59, 0.25),
+                                build_keyframe(-118, 0.50),
+                                build_keyframe(-177, 0.75),
+                                build_keyframe(-236, 0.9),
+                                build_keyframe(-236, 1.0),
+                            ],
+                            child = render_DivisionStandings(standings),
+                            wait_for_child = True,
+                        ),
+                    ],
+                ),
+            ] + table_rows,
+        ),
+    )
+
+def render_table_row(info):
+    team = TEAM_INFO[info.TeamId]
+    if info.Clinched:
+        # clinchers get the same rainbow treatment the card gives them
+        abbrev = render_rainbow_word(team.Abbreviation, SMALL_FONT)
+    else:
+        abbrev = render.Text(
+            content = team.Abbreviation,
+            font = SMALL_FONT,
+            color = team.ForegroundColor,
+        )
+    return render.Box(
+        height = 6,
+        width = 64,
+        color = team.BackgroundColor,
+        child = render.Row(
+            expanded = True,
+            main_align = "start",
+            cross_align = "center",
+            children = [
+                render.Box(
+                    width = 1,
+                    height = 5,
+                ),
+                render.Box(
+                    width = 13,
+                    height = 5,
+                    child = render.Row(
+                        expanded = True,
+                        main_align = "start",
+                        children = [abbrev],
+                    ),
+                ),
+                render.Box(
+                    width = 27,
+                    height = 5,
+                    child = render.Row(
+                        expanded = True,
+                        main_align = "end",
+                        children = [
+                            render.Text(
+                                content = "{}-{}".format(info.Wins, info.Losses),
+                                font = SMALL_FONT,
+                                color = team.ForegroundColor,
+                            ),
+                        ],
+                    ),
+                ),
+                render.Box(
+                    width = 22,
+                    height = 5,
+                    child = render.Row(
+                        expanded = True,
+                        main_align = "end",
+                        children = [
+                            render.Text(
+                                content = info.GamesBack.removesuffix(".0"),
+                                font = SMALL_FONT,
+                                color = team.ForegroundColor,
+                            ),
+                        ],
+                    ),
+                ),
+            ],
+        ),
+    )
 
 #################
 ## TEAM CONFIG ##


### PR DESCRIPTION
Square (64x64) panels render this app's 2:1 layout top-anchored with the bottom half black. This adds a square layout, gated on `canvas.size()` shape, so 64x64 devices get a display designed for the panel; the 64x32 and 128x64 output is untouched — byte-identical, verified per config below.

## What the square layout shows

On square panels the app keeps the wide layout's top 32 rows verbatim — the flag-flashing division lefter plus the 180-frame easing carousel of 59x32 team-color cards — and spends the new bottom 32 rows on the thing the wide layout never had room for: the whole division table at a glance. Five 6px rows, each on its team's background color, show abbreviation, W-L, and games-back in the app's CG-pixel-3x5-mono/foreground-color language, right-aligned into fixed columns (1+13+27+22px) so the record and GB digits line up down the table; GB gets the same .0-stripping the cards use, and a clinched team's abbreviation gets the same rainbow treatment the card gives its record. The carousel needed an explicit height=32 on the square copy of the Transformation because an unset height fills the 64-tall canvas and pushes the table off-screen. The zero-state becomes a real two-tier square too: the 64x32 league logo on top, the "no standings" marquee centered in the bottom half instead of scrolling over the image. No new HTTP: the table reuses the standings list the app already fetched, and root delay/duration/show_full_animation are unchanged (122 frames on square, same as wide).

## Verification

- 4 configs x {64x32, 128x64} = 8 A/B/A triples; sha256(A1) == sha256(A2) == sha256(B) for every triple (no reruns needed; data never moved). Pristine renders came from `git show HEAD` copies of the app.
- Configs exercised:
  - division=205 (NL Central, default) — leader GB '-', whole-number GB (8 from 8.0), 3-char abbrevs, mid-pan frames
  - division=201 (AL East) — 2-char abbrev TB, all-decimal GB column 4.5–15.5 right-aligned
  - division=203 (NL West) — 2-char abbrevs SD/SF, mixed GB (10 vs 29.5)
  - division=200 (AL West) — tied GB values (17/17), dark palettes ATH/SEA
  - zero-state — forced via temporary hacked copy (standings = []): league image + marquee-below square layout renders
- `pixlet check` passes on pixlet v0.50.1 (the CI pin); cold 64x64 render ~0.12s against the 1s budget.

## Notes for review

- The square Transformation adds height = 32 that the wide layout omits; this is required, not cosmetic — with height unset the widget claims the full 64px canvas and the table lands below the clip (verified by render before/after).
- W-L column (27px) fits a 6-char 100-win record by arithmetic (24px at 4px/char); the widest record observed live was 5 chars (86-53). GB column (22px) fits the theoretical 4-char maximum (e.g. 29.5 rendered).
- CHC's red-on-blue table row is comparatively low contrast, but it is exactly the ForegroundColor/BackgroundColor pair the app's own wide card uses for the Cubs — kept for consistency.
- The 0.12s square render includes the live statsapi.mlb.com fetch: pixlet CLI has no on-disk HTTP cache (none found, no cache flag) and each render is a fresh process; the API is CDN-fast.
- square_render_seconds reported as 0.12 (measured 0.115s wall).
