### PR TITLE
mlbleaders: add a 64x64 layout

### DIFF
--- a/apps/mlbleaders/manifest.yaml
+++ b/apps/mlbleaders/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - mlb
   - baseball
 published: '2022-05-03T15:18:13Z'
-updated: '2026-09-02T07:05:56Z'
+updated: '2026-09-03T04:50:13Z'

--- a/apps/mlbleaders/manifest.yaml
+++ b/apps/mlbleaders/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - mlb
   - baseball
 published: '2022-05-03T15:18:13Z'
-updated: '2025-11-29T17:52:33Z'
+updated: '2026-09-02T07:05:56Z'

--- a/apps/mlbleaders/mlb_leaders.star
+++ b/apps/mlbleaders/mlb_leaders.star
@@ -10,7 +10,7 @@ Author: rs7q5
 
 load("http.star", "http")
 load("random.star", "random")
-load("render.star", "render")
+load("render.star", "canvas", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
@@ -114,6 +114,9 @@ def main(config):
     else:
         statName_vec = [config.str("statName%d" % (idx + 1), x) for idx, x in enumerate(["homeRuns", "hits", "battingAverage"])]
     display_opt = config.bool("show_single", False)
+
+    if is_square():  #square panels get their own vertical layout
+        return main_square(config, statName_vec, display_opt)
 
     frames_all = []
     frames_all2 = []
@@ -397,3 +400,147 @@ def get_frame_multi(stat):
                 if idx2 == 1:  #only show top 2
                     break
     return render.Marquee(render.Row(expanded = False, children = frame_tmp), scroll_direction = "horizontal", width = 64, offset_start = 64, offset_end = 64)
+
+#####################################################
+#functions for square (64x64) displays
+def is_square():
+    #branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
+    #2x square one 128x128, so a bare height test gets both wrong
+    w, h = canvas.size()
+    return h * 2 > w + 16
+
+def main_square(config, statName_vec, display_opt):
+    #square panels have twice the rows, so the leaders stack vertically (like
+    #the single statistic format) instead of scrolling by sideways
+    w, h = canvas.size()
+
+    if display_opt:  #show statistic 1 only (same as wide but more rows visible)
+        x = statName_vec[0]
+        stat_tmp = get_leaders(x)
+
+        if config.bool("title_bkgd", False):
+            title_tmp = render.Box(
+                width = w,
+                height = 5,
+                color = mlb_blue,
+                child = render.Marquee(width = w, child = render.Text(format_title(x), font = font, color = "#fff")),
+            )
+        else:
+            title_tmp = render.Marquee(width = w, child = render.Text(format_title(x), font = font, color = mlb_blue))
+
+        if type(stat_tmp) != "dict":
+            frame_tmp = render.WrappedText(stat_tmp[0], font = font, color = mlb_red)
+        else:
+            frame_tmp = render.Marquee(
+                render.Column(expanded = False, children = get_frame_single_square(stat_tmp, w)),
+                scroll_direction = "vertical",
+                height = h - 5,
+                offset_start = 32,
+                offset_end = 32,
+            )
+        final_frame = render.Column([title_tmp, frame_tmp])
+    else:  #all statistics scroll vertically in one long column
+        frames_all = []
+        for _, x in enumerate(statName_vec):
+            stat_tmp = get_leaders(x)
+            frames_all.extend(get_title_square(format_title(x), w, config.bool("title_bkgd", False)))
+            if type(stat_tmp) != "dict":
+                frames_all.append(render.WrappedText(stat_tmp[0], font = font, color = mlb_red))
+            else:
+                frames_all.extend(get_frame_multi_square(stat_tmp))
+        final_frame = render.Marquee(
+            render.Column(expanded = False, children = frames_all),
+            scroll_direction = "vertical",
+            height = h,
+            offset_start = 32,
+            offset_end = 32,
+        )
+
+    return render.Root(
+        delay = int(config.str("speed", "50")),  #speed up scroll text
+        show_full_animation = True,
+        child = final_frame,
+    )
+
+def get_title_square(title, w, title_bkgd):
+    #stat titles scroll with the stats on a square panel, so wrap long ones
+    #onto multiple full lines (a nested marquee doesn't animate)
+    span = w // 4  #characters per line (font is monospaced 3px wide + 1px space)
+
+    lines = []
+    line_tmp = ""
+    for word in split_sentence(title, span, join_word = True).split(" "):
+        if word == "":
+            continue
+        line_new = word if line_tmp == "" else line_tmp + " " + word
+        if len(line_new) > span:
+            lines.append(line_tmp)
+            line_tmp = word
+        else:
+            line_tmp = line_new
+    if line_tmp != "":
+        lines.append(line_tmp)
+
+    title_tmp = []
+    for idx, line in enumerate(lines):
+        if idx > 0:  #1px gap so wrapped lines don't touch
+            title_tmp.append(render.Box(width = w, height = 1, color = mlb_blue if title_bkgd else "#000"))
+        if title_bkgd:
+            title_tmp.append(render.Stack(children = [
+                render.Box(width = w, height = 5, color = mlb_blue),
+                render.Text(line, font = font, color = "#fff"),
+            ]))
+        else:
+            title_tmp.append(render.Text(line, font = font, color = mlb_blue))
+    return title_tmp
+
+def get_frame_single_square(stat, w):
+    #same rows as get_frame_single (all leaders grabbed), sized to the panel
+    frame_tmp = []
+    for key, val in stat.items():
+        frame_tmp.append(render.Box(width = w, height = 7, child = render.Text(key, font = font), color = "#808080"))
+        if val == []:
+            frame_tmp.append(render.Text("NONE", font = font))
+        else:
+            for idx2, y in enumerate(val):
+                frame_tmp.append(get_leader_row_square(y, color_opts[idx2 % 2]))
+    return frame_tmp
+
+def get_frame_multi_square(stat):
+    #same stats as get_frame_multi (top 2 of each group), one row per leader
+    frame_tmp = []
+    for key, val in stat.items():
+        frame_tmp.append(render.Text(key, font = font, color = mlb_red))
+        if val == []:
+            frame_tmp.append(render.Text("NONE", font = font))
+            continue
+        for idx2, y in enumerate(val):
+            frame_tmp.append(get_leader_row_square(y, color_opts[idx2 % 2]))
+            if idx2 == 1:  #only show top 2
+                break
+    return frame_tmp
+
+def get_leader_row_square(y, ctmp):
+    #one leader row (rank and name on the left, team and value on the right)
+    name_tmp = split_sentence(y[1], 8, join_word = True)
+    name_final = render.WrappedText(content = name_tmp, width = 32, font = font4, color = ctmp)
+    rank_name = render.Row(
+        children = [
+            render.Text("%d." % y[0], font = font4, color = ctmp),  #rank
+            name_final,
+        ],
+    )
+    return render.Row(
+        expanded = True,
+        main_align = "space_between",
+        children = [
+            rank_name,
+            render.Column(
+                cross_align = "end",
+                children = [
+                    render.Text(y[2], font = font, color = ctmp),  #team
+                    render.Text(y[3], font = font, color = mlb_red),  #value
+                ],
+            ),
+        ],
+    )

--- a/apps/mlbleaders/mlb_leaders.star
+++ b/apps/mlbleaders/mlb_leaders.star
@@ -407,7 +407,7 @@ def is_square():
     #branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
     #2x square one 128x128, so a bare height test gets both wrong
     w, h = canvas.size()
-    return h * 2 > w + 16
+    return h == w
 
 def main_square(config, statName_vec, display_opt):
     #square panels have twice the rows, so the leaders stack vertically (like


### PR DESCRIPTION
Square (64x64) panels render this app's 2:1 layout top-anchored with the bottom half black. This adds a square layout, gated on `canvas.size()` shape, so 64x64 devices get a display designed for the panel; the 64x32 and 128x64 output is untouched — byte-identical, verified per config below.

## What the square layout shows

The wide layout spends its 32 rows on three 6px horizontal ticker strips, so only about one leader is legible at any moment; the square layout converts those strips into a full-height vertical table in the app's own single-stat row style: each stat's title, then each statGroup's red key followed by its top-2 leaders as rank + wrapped-name rows with the team abbreviation stacked over the red value at the right edge, all scrolling through the 64px window (roughly 5-6 fully readable rows per frame). The "Show only Statistic 1" mode keeps its wide structure — fixed title marquee up top, gray group-header boxes, all three fetched leaders — but the vertical marquee window grows from 27px to 59px, showing ~2.2x the rows per frame. Because stat titles ride inside the vertical scroll in multi mode and a nested marquee does not animate, long titles (e.g. "Walks And Hits Per Inning Pitched") word-wrap onto full-width 16-char lines, and with the Title Background option they render as a solid blue banner. Same fonts, colors, casing, data (statsapi.mlb.com, one request per stat, same ttl) and delay/offset conventions; every schema option (statName1-3, show_single, show_random, speed, title_bkgd, hide_app) keeps a working effect on the square layout.

## Verification

- Final modified star sha256 = 47254c9e8d68e3b281cfe87682484608e98c2e9b18d750dd39cf25d6a598ff70, unchanged since the B renders (pixlet format verified idempotent). Pristine renders came from `git show HEAD` copies of the app.
- Configs exercised:
  - (default) — multi mode, 3 default stats, all 3 statGroups (hitting/catching/pitching) per stat
  - show_single=true — single vertical mode, fixed title + 59px marquee window
  - title_bkgd=true statName1=strikeouts — multi mode with blue title bars and tied ranks (two rank-2s at 217)
  - show_single=true statName1=strikeouts title_bkgd=true — single mode, blue title box, 4-digit values (1037), ties
  - show_random=true speed=20 — random-stat code path at 20ms delay; naturally exercised the empty-group NONE row (errors/catching)
  - statName1=walksAndHitsPerInningPitched title_bkgd=true — 3-line wrapped title banner, decimal values (0.75)
- `pixlet check` passes on pixlet v0.50.1 (the CI pin); cold 64x64 render ~0.35s against the 1s budget.

## Notes for review

- The HTTP error path (non-200 -> 'Error getting data') and empty-season path ('No Stats!!') could not be forced; the square branch mirrors the wide handling (red WrappedText in the scroll / below the title) but those two states were not visually exercised. The per-group empty path WAS exercised (c5's random draw hit 'errors' whose catching group is empty -> NONE row renders correctly).
- Single mode shows a pre-existing <=1px pixlet Marquee edge-bleed where a partially scrolled row can touch the fixed title's bottom row; I verified frame-by-frame that the PRISTINE wide app exhibits the identical artifact (e.g. baseline c2 64x32 frame 100), so it is not introduced by this port.
- Judgment call: square multi-mode leader rows reuse the single-format row style (value in red under the team) instead of wide multi's inline '(team/value)' in row color, so both square modes share one table language; square multi keeps wide multi's top-2-per-group data choice, square single keeps all fetched leaders (up to 3).
- Names wrap via the app's existing split_sentence(span=8)/WrappedText(width=32) convention, so 9+-char names break mid-word ('Schwarbe r') exactly as wide single mode does today.
- show_random renders are stable within seconds (all three c5 A/B/A invocations hashed identical) but drift across minutes (random picks/live API data), so a reviewer re-running c5 will get different stats than my renders — the A/B/A triple protocol covers this.
- Square multi cycles are long (~250-450 frames with show_full_animation) but comparable to the pristine wide default's 704-frame cycle.
- 128x128 (2x square) not special-cased per the guide; the layout is written against canvas.size() w/h.
