### PR TITLE
mlbmagicnumber: add a 64x64 layout

### DIFF
--- a/apps/mlbmagicnumber/manifest.yaml
+++ b/apps/mlbmagicnumber/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - mlb
   - baseball
 published: '2023-09-05T17:46:47Z'
-updated: '2026-09-02T07:06:05Z'
+updated: '2026-09-03T04:50:15Z'

--- a/apps/mlbmagicnumber/manifest.yaml
+++ b/apps/mlbmagicnumber/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - mlb
   - baseball
 published: '2023-09-05T17:46:47Z'
-updated: '2025-12-02T19:30:22Z'
+updated: '2026-09-02T07:06:05Z'

--- a/apps/mlbmagicnumber/mlb_magic_number.star
+++ b/apps/mlbmagicnumber/mlb_magic_number.star
@@ -418,7 +418,7 @@ def is_square():
     """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
     2x square one 128x128, so a bare height test gets both wrong."""
     w, h = canvas.size()
-    return h * 2 > w + 16
+    return h == w
 
 def render_square(team_id, info):
     w, h = canvas.size()

--- a/apps/mlbmagicnumber/mlb_magic_number.star
+++ b/apps/mlbmagicnumber/mlb_magic_number.star
@@ -38,7 +38,7 @@ load("images/tb_logo.png", TB_LOGO_ASSET = "file")
 load("images/tex_logo.png", TEX_LOGO_ASSET = "file")
 load("images/tor_logo.png", TOR_LOGO_ASSET = "file")
 load("images/was_logo.png", WAS_LOGO_ASSET = "file")
-load("render.star", "render")
+load("render.star", "canvas", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
@@ -87,6 +87,9 @@ def main(config):
     team_id = get_team_to_follow(config)
 
     info = http_get_number(team_id)
+
+    if is_square():
+        return render_square(team_id, info)
 
     if info.Clinched or info.Magic or info.Eliminated or not info.HasData:
         background_color = TEAM_INFO[team_id].BackgroundColor
@@ -407,6 +410,161 @@ def render_elim_with_hue(number, on_hue, off_hue):
             ),
         ],
     )
+
+###################
+## 64x64 SUPPORT ##
+###################
+def is_square():
+    """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
+    2x square one 128x128, so a bare height test gets both wrong."""
+    w, h = canvas.size()
+    return h * 2 > w + 16
+
+def render_square(team_id, info):
+    w, h = canvas.size()
+
+    # same background and delay rules as the wide layout
+    if info.Clinched or info.Magic or info.Eliminated or not info.HasData:
+        background_color = TEAM_INFO[team_id].BackgroundColor
+        if info.Clinched or info.Magic:
+            delay = 100
+        else:
+            delay = 0
+    else:  # if you are in danger of being eliminated, get black background
+        background_color = "#000000"
+        delay = 100
+
+    # the extra rows show the division race the magic number comes from
+    division = []
+    if info.Success:
+        division = http_get_division(team_id)
+
+    if len(division) == 0:
+        # nothing to tabulate, show the league logo instead
+        bottom = render.Box(
+            height = h - 32,
+            width = w,
+            child = render.Image(
+                src = MLB_LEAGUE_IMAGE,
+                width = 32,
+            ),
+        )
+    else:
+        bottom = render_division_table(team_id, division, w)
+
+    return render.Root(
+        delay = delay,
+        child = render.Column(
+            children = [
+                render.Row(
+                    children = [
+                        render_logo(team_id, 32),
+                        render.Box(
+                            height = 32,
+                            width = 32,
+                            color = background_color,
+                            child = render_number_info(team_id, info),
+                        ),
+                    ],
+                ),
+                bottom,
+            ],
+        ),
+    )
+
+def render_division_table(team_id, division, width):
+    # 1px rule, then one 6px row per division team (5 teams = 31px of 32)
+    rows = [
+        render.Box(
+            height = 1,
+            width = width,
+            color = TEAM_INFO[team_id].ForegroundColor,
+        ),
+    ]
+    for entry in division:
+        rows.append(render_division_row(team_id, entry, width))
+    return render.Column(
+        children = rows,
+    )
+
+def render_division_row(team_id, entry, width):
+    team = TEAM_INFO[entry.Id]
+    followed = entry.Id == team_id
+    text_color = team.ForegroundColor if followed else "#FFFFFF"
+
+    # the leader gets its magic number, everyone else their elimination number
+    number_color = text_color
+    if not followed and entry.Number == "E":
+        number_color = BRIGHT_RED
+
+    # pad in the mono font so the columns line up: ABB  W-L  number
+    record = str(entry.Wins) + "-" + str(entry.Losses)
+    left = pad_right(team.Abbreviation, 3) + " " + pad_left(record, 6) + " "
+    return render.Box(
+        height = 6,
+        width = width,
+        color = team.BackgroundColor if followed else "#000000",
+        child = render.Row(
+            children = [
+                render.Text(
+                    content = left,
+                    font = COMMON_FONT,
+                    color = text_color,
+                ),
+                render.Text(
+                    content = pad_left(entry.Number, 3),
+                    font = COMMON_FONT,
+                    color = number_color,
+                ),
+            ],
+        ),
+    )
+
+def pad_left(content, size):
+    return " " * (size - len(content)) + content
+
+def pad_right(content, size):
+    return content + " " * (size - len(content))
+
+def http_get_division(team_id):
+    # same request as http_get_number, so this is served from its cache
+    query_params = {
+        "fields": "records,division,id,teamRecords,team,magicNumber,eliminationNumberDivision,clinched,clinchIndicator,divisionRank,wins,losses",
+        "leagueId": str(TEAM_INFO[team_id].LeagueId),
+        "season": str(time.now().year),
+    }
+
+    # cache response for 5 minutes
+    response = http.get(MLB_STANDINGS_URL, params = query_params, ttl_seconds = 300)
+
+    division = []
+    if not is_response_OK(response):
+        return division
+    records = response.json().get("records")
+    if records == None:
+        return division
+    for record in records:
+        # if it matches our division, collect every team in it
+        if int(record.get("division").get("id")) == TEAM_INFO[team_id].DivisionId:
+            for team_record in record.get("teamRecords"):
+                other_id = int(team_record.get("team").get("id"))
+                if other_id not in TEAM_INFO:
+                    continue
+                number = team_record.get("magicNumber")
+                if number == None:
+                    number = team_record.get("eliminationNumberDivision")
+                if number == None:
+                    number = "-"
+                division.append(
+                    struct(
+                        Id = other_id,
+                        Wins = int(team_record.get("wins")),
+                        Losses = int(team_record.get("losses")),
+                        Number = str(number),
+                    ),
+                )
+            break  # we found our division
+    return division
 
 ######################
 ## HTTP REQUEST API ##


### PR DESCRIPTION
Square (64x64) panels render this app's 2:1 layout top-anchored with the bottom half black. This adds a square layout, gated on `canvas.size()` shape, so 64x64 devices get a display designed for the panel; the 64x32 and 128x64 output is untouched — byte-identical, verified per config below.

## What the square layout shows

The square layout keeps the wide card untouched as the top half — team logo beside the 32x32 number panel, with all five card states and their animations rendered by the exact same functions — and spends the new 32 rows on the division race the magic number is computed from. Below a 1px rule in the team's accent color, all five division teams are listed in the app's CG-pixel-3x5-mono font as ABB / W-L / number, where the number column is the leader's magic number and everyone else's division elimination number: exactly the standings math behind the headline number (the leader's magic number and the runner-up's elimination number visibly match). The followed team's row is highlighted in its own card colors, and an eliminated rival's "E" is set in the app's existing bright red. Background and delay rules mirror the wide branch, so the rainbow cycling, elim flashing, and W/L count-up behave identically while the table stays static; if standings can't be tabulated (bad response / empty preseason data) the bottom half falls back to the centered MLB league logo asset. The table reuses the standings request the app already makes — the second identical http.get is served from the 5-minute cache, so a cold render stays at ~0.05s.

## Verification

- 4 configs x {64x32, 128x64} byte-identical, A/B/A: all 8 triples had sha256(A1)==sha256(A2) (stable data) and sha256(B)==sha256(A1); pristine = git show HEAD star written into a copy of the app dir. Pristine renders came from `git show HEAD` copies of the app.
- Configs exercised:
  - (default, team=158 Brewers) — magic-number state: rainbow card, division-leader row highlighted, magic column populated
  - team=137 (Giants) — eliminated state: W/L counter + flashing div-rank card, followed row shows E in team color, Rockies E in bright red (two-E table)
  - team=112 (Cubs) — elimination-number state: black card with red flash, 2nd-place row highlighted red-on-blue
  - team=118 (Royals) — elimination-number state: last-place highlighted row at table bottom, 2-char 'KC' abbrev column alignment
- `pixlet check` passes on pixlet v0.50.1 (the CI pin); cold 64x64 render ~0.05s against the 1s budget.

## Notes for review

- Clinched, preseason no-data, and HTTP-failure card states are not reachable from the live API today (2026-09-02: no clinches yet, season in progress, API up).
- http_get_division issues a second http.get identical to http_get_number's, served from pixlet's in-render cache — verified no persistent CLI cache exists, cold render measured 0.045-0.05s three times (statsapi responds in ~40ms), well under the 1s pixlet-check budget (which renders wide anyway, so the square branch never runs in CI).
- Judgment call: for a division leader whose magicNumber is '-' (post-wild-card-clinch API quirk), the table row shows '-' as the API states it, rather than replicating the wide card's borrow-the-runner-up's-elimination-number trick; the card itself still applies that logic since it is unchanged.
- The row highlight box uses the team's BackgroundColor, which is #000000 for BAL and MIA — their highlighted row degrades to team-foreground-colored text on black (still distinguishable from the white rivals' rows); not renderable as a followed team in a division race variant beyond the four tested.
- webp frame counts (147 for the Giants eliminated animation, 2 for elim flashing) are encoder-deduplicated from the app's logical frame lists; animation was verified on coalesced frames (counter mid-count W:57 L:63, and the dark-red flash phase) confirming only the card region animates while the table stays static.
- 128x128 (2x square) is unreachable from real servers and was not special-cased per the guide; full-width square elements are written against canvas.size() width.
