### PR TITLE
mlbscores: add a 64x64 layout

### DIFF
--- a/apps/mlbscores/manifest.yaml
+++ b/apps/mlbscores/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - mlb
   - baseball
 published: '2022-04-27T14:37:57Z'
-updated: '2026-09-02T07:06:11Z'
+updated: '2026-09-03T04:50:15Z'

--- a/apps/mlbscores/manifest.yaml
+++ b/apps/mlbscores/manifest.yaml
@@ -13,4 +13,4 @@ tags:
   - mlb
   - baseball
 published: '2022-04-27T14:37:57Z'
-updated: '2026-08-23T13:45:34Z'
+updated: '2026-09-02T07:06:11Z'

--- a/apps/mlbscores/mlb_scores.star
+++ b/apps/mlbscores/mlb_scores.star
@@ -855,7 +855,7 @@ def is_square():
     """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
     2x square one 128x128, so a bare height test gets both wrong."""
     w, h = canvas.size()
-    return h * 2 > w + 16
+    return h == w
 
 def get_square_frames(gameCards):
     """Stack two game cards per frame on a square panel. An odd game out wraps

--- a/apps/mlbscores/mlb_scores.star
+++ b/apps/mlbscores/mlb_scores.star
@@ -7,7 +7,7 @@ Author: LunchBox8484
 
 load("encoding/json.star", "json")
 load("http.star", "http")
-load("render.star", "render")
+load("render.star", "canvas", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
@@ -226,6 +226,10 @@ def main(config):
                         homeScoreColor = "#fff"
                         awayScoreColor = "#fff"
 
+            # on square panels two games share each animation frame, so the
+            # rotating clock in the top shelf advances per frame, not per game
+            frameIndex = i // 2 if is_square() else i
+
             if displayType == "retro":
                 retroTextColor = "#ffe065"
                 retroBorderColor = "#000"
@@ -242,7 +246,7 @@ def main(config):
                                     expanded = True,
                                     main_align = "space_between",
                                     cross_align = "start",
-                                    children = get_date_column(displayTop, now, i, rotationSpeed, retroTextColor, retroBorderColor, displayType, gameTime, timeColor),
+                                    children = get_date_column(displayTop, now, frameIndex, rotationSpeed, retroTextColor, retroBorderColor, displayType, gameTime, timeColor),
                                 ),
                                 render.Column(
                                     children = [
@@ -278,7 +282,7 @@ def main(config):
                                     expanded = True,
                                     main_align = "space_between",
                                     cross_align = "start",
-                                    children = get_date_column(displayTop, now, i, rotationSpeed, textColor, borderColor, displayType, gameTime, timeColor),
+                                    children = get_date_column(displayTop, now, frameIndex, rotationSpeed, textColor, borderColor, displayType, gameTime, timeColor),
                                 ),
                                 render.Column(
                                     children = [
@@ -319,7 +323,7 @@ def main(config):
                                     expanded = True,
                                     main_align = "space_between",
                                     cross_align = "start",
-                                    children = get_date_column(displayTop, now, i, rotationSpeed, textColor, borderColor, displayType, gameTime, timeColor),
+                                    children = get_date_column(displayTop, now, frameIndex, rotationSpeed, textColor, borderColor, displayType, gameTime, timeColor),
                                 ),
                                 render.Row(
                                     expanded = True,
@@ -376,7 +380,7 @@ def main(config):
                                     expanded = True,
                                     main_align = "space_between",
                                     cross_align = "start",
-                                    children = get_date_column(displayTop, now, i, rotationSpeed, textColor, borderColor, displayType, gameTime, timeColor),
+                                    children = get_date_column(displayTop, now, frameIndex, rotationSpeed, textColor, borderColor, displayType, gameTime, timeColor),
                                 ),
                                 render.Row(
                                     expanded = True,
@@ -419,7 +423,7 @@ def main(config):
                                     expanded = True,
                                     main_align = "space_between",
                                     cross_align = "start",
-                                    children = get_date_column(displayTop, now, i, rotationSpeed, textColor, borderColor, displayType, gameTime, timeColor),
+                                    children = get_date_column(displayTop, now, frameIndex, rotationSpeed, textColor, borderColor, displayType, gameTime, timeColor),
                                 ),
                                 render.Row(
                                     expanded = True,
@@ -464,7 +468,7 @@ def main(config):
                                     expanded = True,
                                     main_align = "space_between",
                                     cross_align = "start",
-                                    children = get_date_column(displayTop, now, i, rotationSpeed, textColor, borderColor, displayType, gameTime, timeColor),
+                                    children = get_date_column(displayTop, now, frameIndex, rotationSpeed, textColor, borderColor, displayType, gameTime, timeColor),
                                 ),
                                 render.Row(
                                     expanded = True,
@@ -491,6 +495,19 @@ def main(config):
                         ),
                     ],
                 )
+
+        if is_square():
+            return render.Root(
+                delay = int(rotationSpeed) * 1000,
+                show_full_animation = True,
+                child = render.Column(
+                    children = [
+                        render.Animation(
+                            children = get_square_frames(renderCategory),
+                        ),
+                    ],
+                ),
+            )
 
         return render.Root(
             delay = int(rotationSpeed) * 1000,
@@ -833,6 +850,26 @@ def get_schema():
             ),
         ],
     )
+
+def is_square():
+    """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
+    2x square one 128x128, so a bare height test gets both wrong."""
+    w, h = canvas.size()
+    return h * 2 > w + 16
+
+def get_square_frames(gameCards):
+    """Stack two game cards per frame on a square panel. An odd game out wraps
+    around to pair with the first card so the bottom half never sits empty."""
+    w, h = canvas.size()
+    frames = []
+    for i in range(0, len(gameCards), 2):
+        pair = [render.Box(width = w, height = h // 2, child = gameCards[i])]
+        if i + 1 < len(gameCards):
+            pair.append(render.Box(width = w, height = h // 2, child = gameCards[i + 1]))
+        elif len(gameCards) > 1:
+            pair.append(render.Box(width = w, height = h // 2, child = gameCards[0]))
+        frames.append(render.Column(children = pair))
+    return frames
 
 def get_scores(urls, team):
     allscores = []


### PR DESCRIPTION
Square (64x64) panels render this app's 2:1 layout top-anchored with the bottom half black. This adds a square layout, gated on `canvas.size()` shape, so 64x64 devices get a display designed for the panel; the 64x32 and 128x64 output is untouched — byte-identical, verified per config below.

## What the square layout shows

On square panels the app stacks two complete 32px game cards per animation frame — each card keeps its own top shelf (league/clock + game status) and its own displayType body, so all six styles (colors, black, logos, horizontal, stadium, retro) work unchanged one size up. Two games per frame means the rotation covers the slate in half the cycle time, and a team-focus config now shows the last final and the next game (with records) together on one static frame. An odd game out wraps around to pair with the first card so the bottom half never sits empty. The only touch to shared code is the shelf-clock index: with two games per frame the rotating displayTop=time clock must advance per frame rather than per game so both stacked cards agree on the time; on wide panels the index is arithmetically unchanged and the output is proven byte-identical. Frame delay conventions are kept (delay = rotationSpeed * 1000 per frame).

## Verification

- 6 configs x {64x32, 128x64} = 12/12 byte-identical, A/B/A (pristine from git show HEAD written into a copied app dir; sha256(A1)==sha256(A2) required, then sha256(B)==sha256(A1)). One triple (retro/time config at 128x64) hit A1!=A2 from a clock-minute rollover and passed on automatic re-run. Pristine renders came from `git show HEAD` copies of the app.
- Configs exercised:
  - (default: colors, league shelf, record pregame) — 15 final games, 8 square frames incl. the wrap-around frame
  - displayType=retro displayTop=time displayTimeColor=#F00 — retro branch + rotating clock; both stacked cards share one clock that advances per frame
  - displayType=stadium pregameDisplay=odds — stadium borders and card seams
  - displayType=logos displayTop=gameinfo — full-width game-info shelf; logo bleed matches the wide layout's own look
  - selectedTeam=NYY displayType=horizontal rotationSpeed=10 pregameDisplay=nothing — team focus pairing final + upcoming (pre state) in one frame, non-default rotation
  - selectedTeam=BOS displayType=black pregameDisplay=record — black branch + pregame records rendered on square
- `pixlet check` passes on pixlet v0.50.1 (the CI pin); cold 64x64 render ~0.33s against the 1s budget.

## Notes for review

- One deliberate touch to existing lines beyond the load() exception: the six identical get_date_column call sites now pass frameIndex (i // 2 on square, exactly i on wide) instead of i, plus one added assignment. Without it the two stacked cards would show clocks rotationSpeed seconds apart and the displayTop=time clock would run 2x fast. Wide byte-identity after this change is proven by the A/B/A above, including the displayTop=time config that exercises the changed argument.
- Single-game state (team focus returning exactly one game) could not be forced live — every probed team (NYY, BOS, ATH, COL, MIA, TB, CHW) returned 2+ games. In that state the code renders the lone card in the top half over an empty bottom half (the elif len > 1 guard prevents duplicating one game).
- Live in-progress games not exercised: renders ran ~2:30 AM ET so every scoreboard game was post or pre. The square change only stacks the already-built cards (all six card types are exactly 8+24=32px), so 'in' cards get no new geometry.
- pregameDisplay=odds was A/B/A-tested but no pregame game carried odds content at render time; the odds path builds card content this diff does not touch.
- No-games state is unchanged: the square branch sits inside the existing len(scores) > 0 guard, so the app still returns [] when empty.
- Cycle time halves on square (2 games per frame at the same per-frame delay) — this is the intended semantics per the rotating-games convention.
- get_square_frames sizes its half-frame boxes from canvas.size(), so an (currently unreachable) 128x128 canvas centers the 64x32 cards per half instead of breaking; no 2x-square special casing.
