### PR TITLE
mlbstatsleaders: add a 64x64 layout

### DIFF
--- a/apps/mlbstatsleaders/mlbstatsleaders.star
+++ b/apps/mlbstatsleaders/mlbstatsleaders.star
@@ -6,7 +6,7 @@ Author: symm512
 """
 
 load("http.star", "http")
-load("render.star", "render")
+load("render.star", "canvas", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
@@ -160,6 +160,12 @@ def format_name(full_name, stat_key):
 def normalize(s):
     return (s or "").lower().replace(" ", "").replace("-", "")
 
+def is_square():
+    """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
+    2x square one 128x128, so a bare height test gets both wrong."""
+    w, h = canvas.size()
+    return h * 2 > w + 16
+
 def fetch_leaders(stat_key):
     if stat_key == "None":
         return []
@@ -182,6 +188,37 @@ def fetch_leaders(stat_key):
     leaders = []
 
     for l in leaders_data[:5]:
+        leaders.append({
+            "name": format_name(l["person"]["fullName"], stat_key),
+            "team": TEAM_NAME_MAP.get(l["team"].get("name"), l["team"].get("abbreviation", l["team"].get("name", "???"))),
+            "value": l["value"],
+        })
+    return leaders
+
+def fetch_leaders_square(stat_key):
+    """Same feed as fetch_leaders, but asks for ten names so the square
+    panel can show a full top-10 board."""
+    if stat_key == "None":
+        return []
+
+    config = STAT_CONFIG[stat_key]
+    url = "https://statsapi.mlb.com/api/v1/stats/leaders?leaderCategories={}&statGroup={}&season={}&limit=10".format(
+        config["api"],
+        config["group"],
+        time.now().year,
+    )
+    res = http.get(url, ttl_seconds = 3600)
+    if res.status_code != 200:
+        return []
+
+    data = res.json()
+    league_leaders = data.get("leagueLeaders")
+    if not league_leaders or len(league_leaders) == 0:
+        return []
+    leaders_data = league_leaders[0].get("leaders", [])
+    leaders = []
+
+    for l in leaders_data[:10]:
         leaders.append({
             "name": format_name(l["person"]["fullName"], stat_key),
             "team": TEAM_NAME_MAP.get(l["team"].get("name"), l["team"].get("abbreviation", l["team"].get("name", "???"))),
@@ -246,6 +283,25 @@ def render_stat_slide(stat_key, leaders):
 
     return render.Column(children = rows)
 
+def main_square(rotation_speed, selected_stats):
+    """64x64: the same boards on the same rotation, ten leaders deep.
+    Title (5px) plus ten 6px rows fills the panel with no dead band."""
+    slides = []
+    for stat in selected_stats:
+        leaders = fetch_leaders_square(stat)
+        if leaders:
+            slides.append(render_stat_slide(stat, leaders))
+
+    if not slides:
+        return render.Root(
+            child = render.WrappedText("No Stats Found"),
+        )
+
+    return render.Root(
+        delay = rotation_speed * 1000,
+        child = render.Animation(children = slides),
+    )
+
 def main(config):
     rotation_speed = int(config.get("speed", "3"))
     selected_stats = []
@@ -256,6 +312,9 @@ def main(config):
 
     if not selected_stats:
         selected_stats = ["HR", "ERA"]
+
+    if is_square():
+        return main_square(rotation_speed, selected_stats)
 
     slides = []
     for stat in selected_stats:

--- a/apps/mlbstatsleaders/mlbstatsleaders.star
+++ b/apps/mlbstatsleaders/mlbstatsleaders.star
@@ -164,7 +164,7 @@ def is_square():
     """Branch on canvas SHAPE, not size: a 2x wide panel reports 128x64 and a
     2x square one 128x128, so a bare height test gets both wrong."""
     w, h = canvas.size()
-    return h * 2 > w + 16
+    return h == w
 
 def fetch_leaders(stat_key):
     if stat_key == "None":


### PR DESCRIPTION
Square (64x64) panels render this app's 2:1 layout top-anchored with the bottom half black. This adds a square layout, gated on `canvas.size()` shape, so 64x64 devices get a display designed for the panel; the 64x32 and 128x64 output is untouched — byte-identical, verified per config below.

## What the square layout shows

On wide panels this app rotates top-5 leaderboards: a 5px title over five 6px team-colored rows (35px), which on a 64x64 panel left a 29px dead band. The square branch keeps the exact same board — identical title, fonts, team colors, and row widget (it reuses render_leader_row and render_stat_slide verbatim) — but fetches ten leaders per category instead of five, so each stat page becomes a full top-10. The data comes from the same statsapi.mlb.com leaders endpoint with an added limit=10 (the API defaults to 5), same 3600s TTL. Title (5px) plus ten 6px rows fills the 64px height edge to edge: the tenth colored row lands exactly on y=59-63, with only the always-blank 1px spacer under it clipped — the same clipping idiom the wide layout already uses (35px of column on a 32px panel). Rotation semantics are unchanged: one stat per frame, delay = speed * 1000, same slide order, same No Stats Found fallback.

## Verification

- B hashes: default 1x ffca2ed2, 2x 7b98dce2; hitting 1x e8bc2f55, 2x d3a59d0f; pitching 1x d16fc081, 2x fe4053e1; single 1x 88e33482, 2x fa9c6403. Pristine renders came from `git show HEAD` copies of the app.
- Configs exercised:
  - (default, no config) — HR+ERA fallback when no stats selected; integer and decimal value formats
  - speed=2 stat1=AVG stat2=OPS stat3=SB — hitting rate stats, the 8-char OPS name truncation, 5-char values, 2s rotation
  - speed=5 stat1=WHIP stat2=SOP stat3=W — pitching stat group, 5s rotation verified in output frame durations (5000ms via webpmux)
  - stat1=ERA — single-stat animation, stat2..stat10 left at default None (exercises the None filter)
- `pixlet check` passes on pixlet v0.50.1 (the CI pin); cold 64x64 render ~0.38s against the 1s budget.

## Notes for review

- fetch_leaders_square deliberately mirrors fetch_leaders with limit=10 appended rather than parameterizing the existing function, to keep the wide code path byte-untouched; upstream may prefer folding both into one function with a count argument.
- limit=10 is a new query parameter on the same endpoint/host with the same ttl_seconds=3600; it caches under a separate key from the wide URL (verified the API honors it for counting stats, rate stats, and pitching categories).
- The square No Stats Found state could not be exercised (requires an API failure or empty leagueLeaders); main_square reuses the identical fallback code as wide.
- OPS rank-1 value (1.036, 5 chars) loses ~2px of its last digit at the right edge — pre-existing wide behavior (46px name box + 20px text > 64px), inherited unchanged on square.
- If the API ever returns fewer than 10 leaders for a category the square board shows fewer rows with black below; not observed in-season (all tested categories return exactly 10).
- The square column is nominally 65px; the clipped 65th pixel row is the always-blank spacer under the tenth row — verified by pixel dump that content ends exactly at y=63. Same idiom as wide, whose 35px column already clips on a 32px panel.
- The 0.38s square render time was measured cold (fresh cache dirs, never-before-fetched stat categories, 3 HTTPS fetches); warm-cache renders take ~0.04s. pixlet check (wide, default config, 2 fetches) passes within the 1s CI budget.
- Worktree left uncommitted as instructed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a top-10 MLB leaders display for square screens.
  * Retained the top-5 leaderboard layout for rectangular screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->