### PR TITLE
eplscores, mlsscores: stop two render aborts

### DIFF
--- a/apps/eplscores/eplscores.star
+++ b/apps/eplscores/eplscores.star
@@ -150,17 +150,22 @@ def main(config):
                 else:
                     gameTime = convertedTime.format("3:04 PM")
                 if pregameDisplay == "odds":
-                    checkOdds = competition.get("odds", "NO")
-                    if checkOdds != "NO":
-                        theOdds = competition["odds"][1]
-                        checkHomeOdds = theOdds.get("homeTeamOdds", "NO")
-                        checkAwayOdds = theOdds.get("awayTeamOdds", "NO")
-                        if checkHomeOdds != "NO" and checkAwayOdds != "NO":
-                            homeScore = get_odds(float(competition["odds"][1]["homeTeamOdds"]["moneyLine"]))
-                            awayScore = get_odds(float(competition["odds"][1]["awayTeamOdds"]["moneyLine"]))
-                        else:
-                            homeScore = ""
-                            awayScore = ""
+                    # ESPN returns at most one odds entry, that entry is often
+                    # JSON null, and when it is not it frequently carries no
+                    # moneyLine. Indexing any of those directly aborts the whole
+                    # render, which leaves the panel frozen on its last frame.
+                    oddsList = competition.get("odds") or []
+                    theOdds = oddsList[0] if len(oddsList) > 0 else None
+                    homeTeamOdds = (theOdds or {}).get("homeTeamOdds") or {}
+                    awayTeamOdds = (theOdds or {}).get("awayTeamOdds") or {}
+                    checkHomeOdds = homeTeamOdds.get("moneyLine")
+                    checkAwayOdds = awayTeamOdds.get("moneyLine")
+                    if checkHomeOdds != None and checkAwayOdds != None:
+                        homeScore = get_odds(float(checkHomeOdds))
+                        awayScore = get_odds(float(checkAwayOdds))
+                    else:
+                        homeScore = ""
+                        awayScore = ""
                 elif pregameDisplay == "record":
                     checkSeries = competition.get("series", "NO")
                     checkRecord = homeCompetitor.get("records", "NO")
@@ -194,11 +199,14 @@ def main(config):
             if gameStatus == "post":
                 gameTime = s["status"]["type"]["shortDetail"]
                 gameName = s["status"]["type"]["name"]
-                checkSeries = competition.get("series", "NO")
-                checkNotes = len(competition["notes"])
+                checkSeries = competition.get("series") or "NO"
+                checkNotes = len(competition.get("notes") or [])
                 if checkSeries != "NO":
-                    seriesSummary = competition["series"]["summary"]
-                    gameTime = seriesSummary.replace("series ", "")
+                    # A soccer series object carries competitors/title/completed
+                    # but no summary, so indexing it aborts the render.
+                    seriesSummary = checkSeries.get("summary", "")
+                    if seriesSummary != "":
+                        gameTime = seriesSummary.replace("series ", "")
                 if checkNotes > 0 and checkSeries == "NO":
                     gameHeadline = competition["notes"][0]["headline"]
                     if gameHeadline.find(" - ") > 0:

--- a/apps/eplscores/manifest.yaml
+++ b/apps/eplscores/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - real-time
   - soccer
 published: '2022-09-15T19:39:29Z'
-updated: '2026-09-03T04:51:43Z'
+updated: '2026-09-07T02:19:47Z'

--- a/apps/mlsscores/manifest.yaml
+++ b/apps/mlsscores/manifest.yaml
@@ -12,4 +12,4 @@ tags:
   - real-time
   - soccer
 published: '2022-06-10T17:41:15Z'
-updated: '2025-11-29T17:52:33Z'
+updated: '2026-09-07T02:19:47Z'

--- a/apps/mlsscores/mls_scores.star
+++ b/apps/mlsscores/mls_scores.star
@@ -147,17 +147,22 @@ def main(config):
                 else:
                     gameTime = convertedTime.format("3:04 PM")
                 if pregameDisplay == "odds":
-                    checkOdds = competition.get("odds", "NO")
-                    if checkOdds != "NO":
-                        theOdds = competition["odds"][1]
-                        checkHomeOdds = theOdds.get("homeTeamOdds", "NO")
-                        checkAwayOdds = theOdds.get("awayTeamOdds", "NO")
-                        if checkHomeOdds != "NO" and checkAwayOdds != "NO":
-                            homeScore = get_odds(float(competition["odds"][1]["homeTeamOdds"]["moneyLine"]))
-                            awayScore = get_odds(float(competition["odds"][1]["awayTeamOdds"]["moneyLine"]))
-                        else:
-                            homeScore = ""
-                            awayScore = ""
+                    # ESPN returns at most one odds entry, that entry is often
+                    # JSON null, and when it is not it frequently carries no
+                    # moneyLine. Indexing any of those directly aborts the whole
+                    # render, which leaves the panel frozen on its last frame.
+                    oddsList = competition.get("odds") or []
+                    theOdds = oddsList[0] if len(oddsList) > 0 else None
+                    homeTeamOdds = (theOdds or {}).get("homeTeamOdds") or {}
+                    awayTeamOdds = (theOdds or {}).get("awayTeamOdds") or {}
+                    checkHomeOdds = homeTeamOdds.get("moneyLine")
+                    checkAwayOdds = awayTeamOdds.get("moneyLine")
+                    if checkHomeOdds != None and checkAwayOdds != None:
+                        homeScore = get_odds(float(checkHomeOdds))
+                        awayScore = get_odds(float(checkAwayOdds))
+                    else:
+                        homeScore = ""
+                        awayScore = ""
                 elif pregameDisplay == "record":
                     checkSeries = competition.get("series", "NO")
                     checkRecord = homeCompetitor.get("records", "NO")
@@ -191,11 +196,14 @@ def main(config):
             if gameStatus == "post":
                 gameTime = s["status"]["type"]["shortDetail"]
                 gameName = s["status"]["type"]["name"]
-                checkSeries = competition.get("series", "NO")
-                checkNotes = len(competition["notes"])
+                checkSeries = competition.get("series") or "NO"
+                checkNotes = len(competition.get("notes") or [])
                 if checkSeries != "NO":
-                    seriesSummary = competition["series"]["summary"]
-                    gameTime = seriesSummary.replace("series ", "")
+                    # A soccer series object carries competitors/title/completed
+                    # but no summary, so indexing it aborts the render.
+                    seriesSummary = checkSeries.get("summary", "")
+                    if seriesSummary != "":
+                        gameTime = seriesSummary.replace("series ", "")
                 if checkNotes > 0 and checkSeries == "NO":
                     gameHeadline = competition["notes"][0]["headline"]
                     if gameHeadline.find(" - ") > 0:


### PR DESCRIPTION
Two crashes in the same shape: guard a parent object with `.get()`, then hard-index a child ESPN doesn't always send. There's no `try/except` in Starlark, so each aborts the whole render and the panel sits on its last frame until something else changes it.

Both apps are affected identically — the blocks are byte-identical between the two files.

### 1. Gambling Odds — pre-game, needs the setting

```
theOdds = competition["odds"][1]
```

`odds` has exactly **one** element, so this is index 1 of a 1-item list — an unconditional abort for anyone who picks "Gambling Odds".

The index was never right. `git log -S` shows it was written as `[1]` in each file's first commit (`52e7d54f4` 2022-06-10 for MLS, `afdc345bc` 2022-09-15 for EPL), and the *same commit* that introduced it wrote `[0]` for the NFL app. All 14 sibling scores apps use `[0]`.

But `[1]` → `[0]` alone still crashes, in two more ways I measured against the live feed today:

| shape | frequency measured | what it does to `[0]` |
|---|---|---|
| `"odds": [null]` | **44 of 60** upcoming MLS fixtures | element is null → `.get()` on it aborts |
| DraftKings soccer entry, no `homeTeamOdds` | **20 of 20** upcoming EPL fixtures | handled by the existing guard → blank |
| Bet 365 entry, `homeTeamOdds` but no `moneyLine` | 2 of 60 MLS | `["moneyLine"]` aborts |
| `moneyLine` present but null | synthetic | `float(None)` aborts |

So the element is null-checked before any method call, and `moneyLine` is read with `.get()` and tested for `None` rather than indexed.

### 2. Series summary — post-game, **default config, no setting required**

```
checkSeries = competition.get("series", "NO")
if checkSeries != "NO":
    seriesSummary = competition["series"]["summary"]
```

A soccer `series` object carries `competitors / title / completed / totalCompetitions` — and no `summary`. Sampling MLS playoffs (Oct–Dec 2025): **24 of 24** events with a `series` object lack `summary`.

Reproduced against that real payload on the default config:

```
mls_scores.star:197:58: in main
Error: key "summary" not in dict
```

This is the more serious of the two — it needs no user setting, and it fires on every finished MLS playoff match.

### Verification

- Both apps pass `pixlet check` on the pinned CI version (v0.50.1).
- Every previously-crashing case now renders: EPL odds mode live; MLS odds mode across 7 teams whose next fixture is `[null]`; the real playoff payload on default config; and 7 synthetic hostile shapes (odds absent / null / `[]` / `[null]` / Bet 365 without moneyLine / null moneyLine / real moneyLine).
- **Happy path unchanged** — a numeric moneyLine still displays: `NSH +150 / MIA -180`.
- **No behaviour change on the default path**: rendering the same fixture with the default config before and after produces a **byte-identical** 29,386-byte webp.
- eplscores' 64×64 layout still renders on all six display types.

Note `pixlet check` never exercises either path — it renders the default config, and `pregameDisplay` defaults to `record` — so CI was green on both crashing files. The evidence here is the fixture runs, not CI.

### What this does not do

It stops the freezes; it does not restore the odds display. No fixture in any payload I sampled carries `homeTeamOdds.moneyLine`, so odds mode renders **blank** rather than frozen. Actually showing soccer odds needs a soccer-shaped reader (DraftKings exposes `moneyline.home.close.odds` and `details`; Bet 365 exposes a fractional `summary`), which is a feature change and belongs in its own PR — worth flagging so the next reader doesn't reach for `summary` and reintroduce a `float("627/1000")` abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)